### PR TITLE
Fixing delete payload... causes 500 when empty

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -260,10 +260,13 @@ class Client
 		}
 
 		$requestUri = $baseUri . $uri;
-		$requestOptions = [
-			'query' => is_array($query) ? $query : [],
-			'body'  => is_array($body) ? json_encode($body) : $body,
-		];
+		$requestOptions = [];
+		if ($method != 'DELETE') {
+			$requestOptions = [
+				'query' => is_array($query) ? $query : [],
+				'body'  => is_array($body) ? json_encode($body) : $body,
+			];
+		}
 
 		if (!$this->isUsingGuzzle6()) {
 			try {


### PR DESCRIPTION
I made a change in the code that fixes an error I was having for deleting a deployment specifically.