### PR TITLE
Support for specifying options when deleting a resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,16 @@ $replicationController = $client->replicationControllers()->setLabelSelector([
 ])->first();
 $client->replicationControllers()->delete($replicationController);
 ```
+
+You can also specify options when performing a deletion, eg. to perform [cascading delete]( https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#setting-the-cascading-deletion-policy)
+
+```php
+use Maclof\Kubernetes\Models\DeleteOptions;
+
+$client->replicationControllers()->delete($replicationController,
+   new DeleteOptions(['propagationPolicy' => 'Background']));
+```
+
+See the API documentation for an explanation of the options:
+
+https://kubernetes.io/docs/api-reference/v1.6/#deleteoptions-v1-meta

--- a/src/Client.php
+++ b/src/Client.php
@@ -267,11 +267,11 @@ class Client
 
 		$requestUri = $baseUri . $uri;
 		$requestOptions = [];
-		if ($method != 'DELETE') {
-			$requestOptions = [
-				'query' => is_array($query) ? $query : [],
-				'body'  => is_array($body) ? json_encode($body) : $body,
-			];
+		if (is_array($query) && !empty($query)) {
+			$requestOptions['query'] = $query;
+		}
+		if ($body !== null) {
+			$requestOptions['body'] = is_array($body) ? json_encode($body) : $body;
 		}
 
 		if (!$this->isUsingGuzzle6()) {

--- a/src/Models/DeleteOptions.php
+++ b/src/Models/DeleteOptions.php
@@ -1,0 +1,6 @@
+<?php namespace Maclof\Kubernetes\Models;
+
+class DeleteOptions extends Model
+{
+
+}

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -1,5 +1,6 @@
 <?php namespace Maclof\Kubernetes\Repositories;
 
+use Maclof\Kubernetes\Models\DeleteOptions;
 use Maclof\Kubernetes\Models\Model;
 
 abstract class Repository
@@ -84,26 +85,29 @@ abstract class Repository
 	/**
 	 * Delete a model.
 	 *
-	 * @param  \Maclof\Kubernetes\Models\Model $model
+	 * @param  \Maclof\Kubernetes\Models\Model         $model
+	 * @param  \Maclof\Kubernetes\Models\DeleteOptions $options
 	 * @return boolean
 	 */
-	public function delete(Model $model)
+	public function delete(Model $model, DeleteOptions $options=null)
 	{
-		return $this->deleteByName($model->getMetadata('name'));
+		return $this->deleteByName($model->getMetadata('name'), $options);
 	}
 
 	/**
 	 * Delete a model by name.
 	 *
-	 * @param  string $name
+	 * @param  string                                  $name
+	 * @param  \Maclof\Kubernetes\Models\DeleteOptions $options
 	 * @return boolean
 	 */
-	public function deleteByName($name)
+	public function deleteByName($name, DeleteOptions $options=null)
 	{
+		$body = $options ? $options->getSchema() : null;
 		if ($this->beta) {
-			$this->client->sendBetaRequest('DELETE', '/' . $this->uri . '/' . $name);
+			$this->client->sendBetaRequest('DELETE', '/' . $this->uri . '/' . $name, null, $body);
 		} else {
-			$this->client->sendRequest('DELETE', '/' . $this->uri . '/' . $name);
+			$this->client->sendRequest('DELETE', '/' . $this->uri . '/' . $name, null, $body);
 		}
 		return true;
 	}


### PR DESCRIPTION
Allows you to to include options with your delete call, such as `propagationPolicy` (so you can do cascading deletes) and `gracePeriodSeconds`.

https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#setting-the-cascading-deletion-policy
https://kubernetes.io/docs/api-reference/v1.6/#deleteoptions-v1-meta