### PR TITLE
Remove whitespace from token before using it

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -215,7 +215,7 @@ class Client
 				$token = file_get_contents($token);
 			}
 
-			$options['headers']['Authorization'] = 'Bearer ' . $token;
+			$options['headers']['Authorization'] = 'Bearer ' . trim($token);
 		}
 		if ($this->username && $this->password) {
 			$options['auth'] = [


### PR DESCRIPTION
If token file contains trailing whitespace it subtly breaks http communication leading to headaches.