### PR TITLE
Support PATCH verb (and add Content-Type header for all PATCH requests)

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -325,6 +325,10 @@ class Client
 			$requestOptions['body'] = is_array($body) ? json_encode($body) : $body;
 		}
 
+		if ($method === 'PATCH') {
+		    $requestOptions['headers'] = ['Content-Type' => 'application/strategic-merge-patch+json'];
+        }
+
 		if (!$this->isUsingGuzzle6()) {
 			try {
 				$request = $this->guzzleClient->createRequest($method, $requestUri, $requestOptions);

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -115,6 +115,17 @@ abstract class Repository
 		return $this->sendRequest('PUT', '/' . $this->uri . '/' . $model->getMetadata('name'), null, $model->getSchema(), $this->namespace);
 	}
 
+    /**
+     * Patch a model.
+     *
+     * @param \Maclof\Kubernetes\Models\Model $model
+     * @return array
+     */
+	public function patch(Model $model)
+    {
+        return $this->sendRequest('PATCH', '/' . $this->uri . '/' . $model->getMetadata('name'), null, $model->getSchema(), $this->namespace);
+    }
+
 	/**
 	 * Delete a model.
 	 *


### PR DESCRIPTION
Kubernetes supports patching objects. A partial model may be presented to the API, with only the data that should be updated. For instance: change the image for the pod spec of a Deployment to perform a rolling update.
The only catch for PATCH requests is that the Content-Type request header needs to be set to an exotic MIME type (application/strategic-merge-patch+json). This is done in the `Client::sendRequest()` method if `$method` equals `PATCH`.