### PR TITLE
Feature/networkpolicy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ $ composer require maclof/kubernetes-client
 * Deployments
 * Ingresses
 
+### networking.k8s.io/v1
+* Network Policies
 
 ## Basic Usage
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -15,6 +15,7 @@ use Maclof\Kubernetes\Repositories\EndpointRepository;
 use Maclof\Kubernetes\Repositories\EventRepository;
 use Maclof\Kubernetes\Repositories\IngressRepository;
 use Maclof\Kubernetes\Repositories\JobRepository;
+use Maclof\Kubernetes\Repositories\NetworkPolicyRepository;
 use Maclof\Kubernetes\Repositories\NodeRepository;
 use Maclof\Kubernetes\Repositories\PersistentVolumeRepository;
 use Maclof\Kubernetes\Repositories\PersistentVolumeClaimRepository;
@@ -46,6 +47,7 @@ use Maclof\Kubernetes\Models\PersistentVolume;
  * @method DeploymentRepository deployments()
  * @method IngressRepository ingresses()
  * @method NamespaceRepository namespaces()
+ * @method NetworkPolicyRepository networkPolicies()
  */
 class Client
 {
@@ -157,6 +159,9 @@ class Client
 		'daemonSets'             => 'Repositories\DaemonSetRepository',
 		'deployments'            => 'Repositories\DeploymentRepository',
 		'ingresses'              => 'Repositories\IngressRepository',
+
+        // networking.k8s.io/v1
+        'networkPolicies'        => 'Repositories\NetworkPolicyRepository',
 	];
 
 	/**

--- a/src/Collections/NetworkPolicyCollection.php
+++ b/src/Collections/NetworkPolicyCollection.php
@@ -1,0 +1,31 @@
+<?php namespace Maclof\Kubernetes\Collections;
+
+use Maclof\Kubernetes\Models\NetworkPolicy;
+
+class NetworkPolicyCollection extends Collection
+{
+    /**
+     * The constructor.
+     *
+     * @param array $data
+     */
+    public function __construct(array $data)
+    {
+        parent::__construct($this->getPolicies(isset($data['items']) ? $data['items'] : []));
+    }
+
+    /**
+     * Get an array of network policies.
+     *
+     * @param  array  $items
+     * @return array
+     */
+    protected function getPolicies(array $items)
+    {
+        foreach ($items as &$item) {
+            $item = new NetworkPolicy($item);
+        }
+
+        return $items;
+    }
+}

--- a/src/Models/NetworkPolicy.php
+++ b/src/Models/NetworkPolicy.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: leon
+ * Date: 13-04-18
+ * Time: 14:29
+ */
+
+namespace Maclof\Kubernetes\Models;
+
+class NetworkPolicy extends Model
+{
+    /**
+     * The api version.
+     *
+     * @var string
+     */
+    protected $apiVersion = 'networking.k8s.io/v1';
+}

--- a/src/Repositories/NetworkPolicyRepository.php
+++ b/src/Repositories/NetworkPolicyRepository.php
@@ -1,0 +1,13 @@
+<?php namespace Maclof\Kubernetes\Repositories;
+
+use Maclof\Kubernetes\Collections\NetworkPolicyCollection;
+
+class NetworkPolicyRepository extends Repository
+{
+    protected $uri = 'networkpolicies';
+
+    protected function createCollection($response)
+    {
+        return new NetworkPolicyCollection($response);
+    }
+}

--- a/tests/collections/NetworkPolicyCollectionTest.php
+++ b/tests/collections/NetworkPolicyCollectionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use Maclof\Kubernetes\Collections\NetworkPolicyCollection;
+
+class NetworkPolicyCollectionTest extends TestCase
+{
+	protected $items = [
+		[],
+		[],
+		[],
+	];
+
+	protected function getNetworkPolicyCollection()
+	{
+		$podCollection = new NetworkPolicyCollection([
+			'items' => $this->items,
+		]);
+
+		return $podCollection;
+	}
+
+	public function test_get_items()
+	{
+		$podCollection = $this->getNetworkPolicyCollection();
+		$items = $podCollection->toArray();
+
+		$this->assertTrue(is_array($items));
+		$this->assertEquals(3, count($items));
+	}
+}

--- a/tests/fixtures/network-policies/empty.json
+++ b/tests/fixtures/network-policies/empty.json
@@ -1,0 +1,4 @@
+{
+    "kind": "NetworkPolicy",
+    "apiVersion": "networking.k8s.io\/v1"
+}

--- a/tests/models/NetworkPolicyTest.php
+++ b/tests/models/NetworkPolicyTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Maclof\Kubernetes\Models\NetworkPolicy;
+
+class NetworkPolicyTest extends TestCase
+{
+	public function test_get_schema()
+	{
+		$policy = new NetworkPolicy();
+
+		$schema = $policy->getSchema();
+		$fixture = $this->getFixture('network-policies/empty.json');
+
+		$this->assertEquals($schema, $fixture);
+	}
+
+	public function test_get_metadata()
+	{
+		$policy = new NetworkPolicy([
+			'metadata' => [
+				'name' => 'test',
+			],
+		]);
+
+		$metadata = $policy->getMetadata('name');
+
+		$this->assertEquals($metadata, 'test');
+	}
+}


### PR DESCRIPTION
Another PR :) This PR adds support for the NetworkPolicy resource type. I'm using the `networking.k8s.io/v1` version instead of the `extensions/v1beta1` version, which implies Kubernetes 1.9 or up as a requirement.