### PR TITLE
add a method setPatchType in Client to support different patch type

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -176,6 +176,13 @@ class Client
 	protected $classInstances = [];
 
 	/**
+	 * header for patch.
+	 *
+	 * @var array
+	 */
+	protected $patchHeader = ['Content-Type' => 'application/strategic-merge-patch+json'];
+
+	/**
 	 * The constructor.
 	 *
 	 * @param array $options
@@ -233,6 +240,21 @@ class Client
 	public function setNamespace($namespace)
 	{
 		$this->namespace = $namespace;
+	}
+
+	/**
+	 * Set patch header
+	 *
+	 * @param patch type
+	 */
+	public function setPatchType($patchType = "strategic") {
+		if ($patchType == "merge") {
+			$this->patchHeader = ['Content-Type' => 'application/merge-patch+json'];
+		} elseif ($patchType == "json") {
+			$this->patchHeader = ['Content-Type' => 'application/json-patch+json'];
+		} else {
+			$this->patchHeader = ['Content-Type' => 'application/strategic-merge-patch+json'];
+		}
 	}
 
 	/**
@@ -335,7 +357,7 @@ class Client
 		}
 
 		if ($method === 'PATCH') {
-			$requestOptions['headers'] = ['Content-Type' => 'application/strategic-merge-patch+json'];
+			$requestOptions['headers'] = $this->patchHeader;
 		}
 
 		if (!$this->isUsingGuzzle6()) {


### PR DESCRIPTION
patch type can be set 3 different type, each type use different `Content-Type` header: 
- `strategic`  Content-Type: application/strategic-merge-patch+json
- `merge`   Content-Type: application/merge-patch+json
- ` json`   Content-Type: application/json-patch+json