### PR TITLE
fix json encode error from yaml definition

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -156,9 +156,11 @@ class Client
 		// batch/v2alpha1
 		'cronJobs'               => 'Repositories\CronJobRepository',
 
+		// apps/v1
+		'deployments'            => 'Repositories\DeploymentRepository',
+
 		// extensions/v1beta1
 		'daemonSets'             => 'Repositories\DaemonSetRepository',
-		'deployments'            => 'Repositories\DeploymentRepository',
 		'ingresses'              => 'Repositories\IngressRepository',
 
 		// autoscaling/v2beta1

--- a/src/Client.php
+++ b/src/Client.php
@@ -355,7 +355,7 @@ class Client
 			$requestOptions['query'] = $query;
 		}
 		if ($body !== null) {
-			$requestOptions['body'] = is_array($body) ? json_encode($body) : $body;
+			$requestOptions['body'] = is_array($body) ? json_encode($body, JSON_FORCE_OBJECT) : $body;
 		}
 
 		if ($method === 'PATCH') {


### PR DESCRIPTION
Hi, I encounteted a bug when creating deployment from a yaml file.
When {} is used in yaml, json_encode method recognize it as empty array and omit error 400 BadRequest.
But {} is officially used in kubernetes yaml.
e.g.)
https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
```
apiVersion: v1
kind: Pod
metadata:
  name: test-pd
spec:
  containers:
  - image: k8s.gcr.io/test-webserver
    name: test-container
    volumeMounts:
    - mountPath: /cache
      name: cache-volume
  volumes:
  - name: cache-volume
    emptyDir: {}
```

So I fixes json_encode($body) to json_encode($body, JSON_FORCE_OBJECT).

And, I noticed API ver. of 'deployment' is now app/v1.
This is just comment error, so I include this PR.
If it should be separated from this PR, I'll re-create later.