### PR TITLE
Certmanager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.settings/
 /.buildpath
 /.project
+/build

--- a/README.md
+++ b/README.md
@@ -117,6 +117,21 @@ $client = new Client([
 ]);
 ```
 
+## Extending a library
+
+### Custom repositories
+```php
+$repositories = new RepositoryRegistry();
+
+$repositories['things'] = MyApp\Kubernetes\Repository\ThingRepository;
+
+$client = new Client([
+    'master' => 'https://master.mycluster.com','
+], $repositories);
+
+$client->things() //ThingRepository
+```
+
 ## Usage Examples
 
 ### Create/Update a Replication Controller

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ $ composer require maclof/kubernetes-client
 ### networking.k8s.io/v1
 * Network Policies
 
+### certmanager.k8s.io/v1alpha1
+* Certificates
+* Issuers
+
 ## Basic Usage
 
 ```php
@@ -123,13 +127,13 @@ $client = new Client([
 ```php
 $repositories = new RepositoryRegistry();
 
-$repositories['things'] = MyApp\Kubernetes\Repository\ThingRepository;
+$repositories['things'] = MyApp\Kubernetes\Repository\ThingRepository::class;
 
 $client = new Client([
     'master' => 'https://master.mycluster.com','
-], $repositories);
+], null, $repositories);
 
-$client->things() //ThingRepository
+$client->things(); //ThingRepository
 ```
 
 ## Usage Examples

--- a/src/Client.php
+++ b/src/Client.php
@@ -145,45 +145,11 @@ class Client
 	];
 
 	/**
-	 * The class map.
+	 * The repository class registry.
 	 *
-	 * @var array
+	 * @var RepositoryRegistry
 	 */
-	protected $classMap = [
-		// v1
-		'nodes'                  => 'Repositories\NodeRepository',
-		'quotas'                 => 'Repositories\QuotaRepository',
-		'pods'                   => 'Repositories\PodRepository',
-		'replicaSets'            => 'Repositories\ReplicaSetRepository',
-		'replicationControllers' => 'Repositories\ReplicationControllerRepository',
-		'services'               => 'Repositories\ServiceRepository',
-		'secrets'                => 'Repositories\SecretRepository',
-		'events'                 => 'Repositories\EventRepository',
-		'configMaps'             => 'Repositories\ConfigMapRepository',
-		'endpoints'              => 'Repositories\EndpointRepository',
-		'persistentVolume'       => 'Repositories\PersistentVolumeRepository',
-		'persistentVolumeClaims' => 'Repositories\PersistentVolumeClaimRepository',
-		'namespaces'             => 'Repositories\NamespaceRepository',
-
-		// batch/v1
-		'jobs'                   => 'Repositories\JobRepository',
-
-		// batch/v2alpha1
-		'cronJobs'               => 'Repositories\CronJobRepository',
-
-		// apps/v1
-		'deployments'            => 'Repositories\DeploymentRepository',
-
-		// extensions/v1beta1
-		'daemonSets'             => 'Repositories\DaemonSetRepository',
-		'ingresses'              => 'Repositories\IngressRepository',
-
-		// autoscaling/v2beta1
-		'horizontalPodAutoscalers'  => 'Repositories\HorizontalPodAutoscalerRepository',
-
-		// networking.k8s.io/v1
-		'networkPolicies'        => 'Repositories\NetworkPolicyRepository',
-	];
+	protected $classRegistry;
 
 	/**
 	 * The class instances.
@@ -205,10 +171,11 @@ class Client
 	 * @param array $options
 	 * @param \GuzzleHttp\Client $guzzleClient
 	 */
-	public function __construct(array $options = array(), GuzzleClient $guzzleClient = null)
+	public function __construct(array $options = array(), GuzzleClient $guzzleClient = null, RepositoryRegistry $repositoryRegistry = null)
 	{
 		$this->setOptions($options);
 		$this->guzzleClient = $guzzleClient ? $guzzleClient : $this->createGuzzleClient();
+		$this->classRegistry = $repositoryRegistry ? $repositoryRegistry : new RepositoryRegistry();
 	}
 
 	/**
@@ -515,8 +482,8 @@ class Client
 	 */
 	public function __call($name, array $args)
 	{
-		if (isset($this->classMap[$name])) {
-			$class = 'Maclof\Kubernetes\\' . $this->classMap[$name];
+		if (isset($this->classRegistry[$name])) {
+			$class = 'Maclof\Kubernetes\\' . $this->classRegistry[$name];
 
 			return isset($this->classInstances[$name]) ? $this->classInstances[$name] : new $class($this);
 		}

--- a/src/Client.php
+++ b/src/Client.php
@@ -483,7 +483,7 @@ class Client
 	public function __call($name, array $args)
 	{
 		if (isset($this->classRegistry[$name])) {
-			$class = 'Maclof\Kubernetes\\' . $this->classRegistry[$name];
+			$class = $this->classRegistry[$name];
 
 			return isset($this->classInstances[$name]) ? $this->classInstances[$name] : new $class($this);
 		}

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,8 +2,10 @@
 
 use BadMethodCallException;
 use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\ClientInterface as GuzzleClientInterface;
 use GuzzleHttp\Exception\ClientException as GuzzleClientException;
+use GuzzleHttp\Exception\ServerException;
+use Maclof\Kubernetes\Exceptions\ApiServerException;
+use Maclof\Kubernetes\Repositories\CertificateRepository;
 use React\EventLoop\Factory as ReactFactory;
 use React\Socket\Connector as ReactSocketConnector;
 use Ratchet\Client\Connector as WebSocketConnector;
@@ -51,6 +53,8 @@ use Maclof\Kubernetes\Models\PersistentVolume;
  * @method NamespaceRepository namespaces()
  * @method NetworkPolicyRepository networkPolicies()
  * @method HorizontalPodAutoscalerRepository horizontalPodAutoscalers()
+ * @method CertificateRepository certificates()
+ * @method IssuersRepository issuers()
  */
 class Client
 {

--- a/src/Collections/CertificateCollection.php
+++ b/src/Collections/CertificateCollection.php
@@ -1,0 +1,35 @@
+<?php namespace Maclof\Kubernetes\Collections;
+
+use Maclof\Kubernetes\Models\Certificate;
+
+class CertificateCollection extends Collection
+{
+    /**
+     * The constructor.
+     *
+     * @param array $items
+     */
+    public function __construct(array $items)
+    {
+        parent::__construct($this->getCertificates($items));
+    }
+
+    /**
+     * Get an array of certificates.
+     *
+     * @param  array $items
+     * @return array
+     */
+    protected function getCertificates(array $items)
+    {
+        foreach ($items as &$item) {
+            if ($item instanceof Certificate) {
+                continue;
+            }
+
+            $item = new Certificate($item);
+        }
+
+        return $items;
+    }
+}

--- a/src/Collections/IssuerCollection.php
+++ b/src/Collections/IssuerCollection.php
@@ -1,0 +1,35 @@
+<?php namespace Maclof\Kubernetes\Collections;
+
+use Maclof\Kubernetes\Models\Issuer;
+
+class IssuerCollection extends Collection
+{
+    /**
+     * The constructor.
+     *
+     * @param array $items
+     */
+    public function __construct(array $items)
+    {
+        parent::__construct($this->getIssuers($items));
+    }
+
+    /**
+     * Get an array of certificate issuers.
+     *
+     * @param  array $items
+     * @return array
+     */
+    protected function getIssuers(array $items)
+    {
+        foreach ($items as &$item) {
+            if ($item instanceof Issuer) {
+                continue;
+            }
+
+            $item = new Issuer($item);
+        }
+
+        return $items;
+    }
+}

--- a/src/Models/Certificate.php
+++ b/src/Models/Certificate.php
@@ -1,0 +1,8 @@
+<?php namespace Maclof\Kubernetes\Models;
+
+class Certificate extends Model
+{
+
+    protected $apiVersion = 'certmanager.k8s.io/v1alpha1';
+
+}

--- a/src/Models/Issuer.php
+++ b/src/Models/Issuer.php
@@ -1,0 +1,8 @@
+<?php namespace Maclof\Kubernetes\Models;
+
+class Issuer extends Model
+{
+
+    protected $apiVersion = 'certmanager.k8s.io/v1alpha1';
+
+}

--- a/src/Repositories/IssuerRepository.php
+++ b/src/Repositories/IssuerRepository.php
@@ -1,17 +1,17 @@
 <?php namespace Maclof\Kubernetes\Repositories;
 
-use Maclof\Kubernetes\Collections\CertificateCollection;
+use Maclof\Kubernetes\Collections\IssuerCollection;
 use Maclof\Kubernetes\Repositories\Strategy\PatchMergeTrait;
 
-class CertificateRepository extends Repository
+class IssuerRepository extends Repository
 {
     use PatchMergeTrait;
 
-    protected $uri = 'certificates';
+    protected $uri = 'issuers';
 
     protected function createCollection($response)
     {
-        return new CertificateCollection($response['items']);
+        return new IssuerCollection($response['items']);
     }
 
 }

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -126,6 +126,25 @@ abstract class Repository
 		return $this->sendRequest('PATCH', '/' . $this->uri . '/' . $model->getMetadata('name'), null, $model->getSchema(), $this->namespace);
 	}
 
+    /**
+     * Apply a model.
+     *
+     * Creates a new api object if not exists, or patch.
+     *
+     * @param \Maclof\Kubernetes\Models\Model $model
+     * @return array
+     */
+	public function apply(Model $model)
+    {
+        $exists = $this->exists($model->getMetadata("name"));
+
+        if ($exists) {
+            return $this->patch($model);
+        } else {
+            return $this->create($model);
+        }
+    }
+
 	/**
 	 * Delete a model.
 	 *
@@ -258,7 +277,7 @@ abstract class Repository
 
 	/**
 	 * Create a collection of models from the response.
-	 * 
+	 *
 	 * @param  array $response
 	 * @return \Maclof\Kubernetes\Collections\Collection
 	 */

--- a/src/Repositories/Strategy/PatchMergeTrait.php
+++ b/src/Repositories/Strategy/PatchMergeTrait.php
@@ -1,0 +1,19 @@
+<?php namespace Maclof\Kubernetes\Repositories\Strategy;
+
+use Maclof\Kubernetes\Models\Model;
+
+trait PatchMergeTrait {
+
+    public function patch(Model $model)
+    {
+        $this->client->setPatchType("merge");
+
+        $result = parent::patch($model);
+
+        // Reverting default patch type
+        $this->client->setPatchType();
+
+        return $result;
+    }
+
+}

--- a/src/RepositoryRegistry.php
+++ b/src/RepositoryRegistry.php
@@ -1,0 +1,73 @@
+<?php namespace Maclof\Kubernetes;
+
+class RepositoryRegistry implements \ArrayAccess, \Countable
+{
+
+    /**
+     * @var array Initial registry class map. Contains only package builtin repositories.
+     */
+    protected $map = [
+        'nodes'                  => Repositories\NodeRepository::class,
+        'quotas'                 => Repositories\QuotaRepository::class,
+        'pods'                   => Repositories\PodRepository::class,
+        'replicaSets'            => Repositories\ReplicaSetRepository::class,
+        'replicationControllers' => Repositories\ReplicationControllerRepository::class,
+        'services'               => Repositories\ServiceRepository::class,
+        'secrets'                => Repositories\SecretRepository::class,
+        'events'                 => Repositories\EventRepository::class,
+        'configMaps'             => Repositories\ConfigMapRepository::class,
+        'endpoints'              => Repositories\EndpointRepository::class,
+        'persistentVolume'       => Repositories\PersistentVolumeRepository::class,
+        'persistentVolumeClaims' => Repositories\PersistentVolumeClaimRepository::class,
+        'namespaces'             => Repositories\NamespaceRepository::class,
+
+        // batch/v1
+        'jobs'                   => Repositories\JobRepository::class,
+
+        // batch/v2alpha1
+        'cronJobs'               => Repositories\CronJobRepository::class,
+
+        // apps/v1
+        'deployments'            => Repositories\DeploymentRepository::class,
+
+        // extensions/v1beta1
+        'daemonSets'             => Repositories\DaemonSetRepository::class,
+        'ingresses'              => Repositories\IngressRepository::class,
+
+        // autoscaling/v2beta1
+        'horizontalPodAutoscalers'  => Repositories\HorizontalPodAutoscalerRepository::class,
+
+        // networking.k8s.io/v1
+        'networkPolicies'        => Repositories\NetworkPolicyRepository::class,
+    ];
+
+    public function __construct()
+    {
+
+    }
+
+    public function offsetExists($method)
+    {
+        return isset($this->map[$method]);
+    }
+
+    public function offsetGet($method)
+    {
+        return $this->map[$method];
+    }
+
+    public function offsetSet($method, $class)
+    {
+        $this->map[$method] = $class;
+    }
+
+    public function offsetUnset($method)
+    {
+        unset($this->map[$method]);
+    }
+
+    public function count()
+    {
+        return count($this->map);
+    }
+}

--- a/src/RepositoryRegistry.php
+++ b/src/RepositoryRegistry.php
@@ -39,6 +39,11 @@ class RepositoryRegistry implements \ArrayAccess, \Countable
 
         // networking.k8s.io/v1
         'networkPolicies'        => Repositories\NetworkPolicyRepository::class,
+
+        // certmanager.k8s.io/v1alpha1
+        'certificates'           => Repositories\CertificateRepository::class,
+        'issuers'                => Repositories\IssuerRepository::class,
+
     ];
 
     public function __construct()

--- a/tests/RepositoryRegistryTest.php
+++ b/tests/RepositoryRegistryTest.php
@@ -9,7 +9,8 @@ class RepositoryRegistryTest extends TestCase
     {
         $registry = new RepositoryRegistry();
 
-        $this->assertCount(20, $registry);
+
+        $this->assertCount(22, $registry);
     }
 
     public function test_add_repository()

--- a/tests/RepositoryRegistryTest.php
+++ b/tests/RepositoryRegistryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Maclof\Kubernetes\RepositoryRegistry;
+
+class RepositoryRegistryTest extends TestCase
+{
+
+    public function test_builtin_repositories()
+    {
+        $registry = new RepositoryRegistry();
+
+        $this->assertCount(20, $registry);
+    }
+
+    public function test_add_repository()
+    {
+        $registry = new RepositoryRegistry();
+        $class = '\Example\Class';
+
+        $this->assertFalse(isset($registry['test']));
+
+        $registry['test'] = $class;
+
+        $this->assertTrue(isset($registry['test']));
+        $this->assertEquals($class, $registry['test']);
+    }
+}

--- a/tests/collections/CertificateCollectionTest.php
+++ b/tests/collections/CertificateCollectionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Maclof\Kubernetes\Collections\CertificateCollection;
+
+class CertificateCollectionTest extends TestCase
+{
+    protected $items = [
+        [],
+        [],
+        [],
+    ];
+
+    protected function getCertificateCollection()
+    {
+        $configMapCollection = new CertificateCollection($this->items);
+
+        return $configMapCollection;
+    }
+
+    public function test_get_items()
+    {
+        $certificateCollection = $this->getCertificateCollection();
+        $items = $certificateCollection->toArray();
+
+        $this->assertTrue(is_array($items));
+        $this->assertEquals(3, count($items));
+    }
+}

--- a/tests/collections/IssuerCollectionTest.php
+++ b/tests/collections/IssuerCollectionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Maclof\Kubernetes\Collections\IssuerCollection;
+
+class IssuerCollectionTest extends TestCase
+{
+    protected $items = [
+        [],
+        [],
+        [],
+    ];
+
+    protected function getIssuerCollection()
+    {
+        $issuerCollection = new IssuerCollection($this->items);
+
+        return $issuerCollection;
+    }
+
+    public function test_get_items()
+    {
+        $issuerCollection = $this->getIssuerCollection();
+        $items = $issuerCollection->toArray();
+
+        $this->assertTrue(is_array($items));
+        $this->assertEquals(3, count($items));
+    }
+}

--- a/tests/fixtures/certificates/empty.json
+++ b/tests/fixtures/certificates/empty.json
@@ -1,0 +1,4 @@
+{
+    "kind": "Certificate",
+    "apiVersion": "certmanager.k8s.io/v1alpha1"
+}

--- a/tests/fixtures/issuers/empty.json
+++ b/tests/fixtures/issuers/empty.json
@@ -1,0 +1,4 @@
+{
+    "kind": "Issuer",
+    "apiVersion": "certmanager.k8s.io/v1alpha1"
+}

--- a/tests/models/CertificateTest.php
+++ b/tests/models/CertificateTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Maclof\Kubernetes\Models\Certificate;
+
+class CertificateTest extends TestCase
+{
+    public function test_get_schema()
+    {
+        $certificate = new Certificate;
+
+        $schema = trim($certificate->getSchema());
+        $fixture = trim($this->getFixture('certificates/empty.json'));
+
+        $this->assertEquals($fixture, $schema);
+    }
+
+    public function test_get_metadata()
+    {
+        $certificate = new Certificate([
+            'metadata' => [
+                'name' => 'test',
+            ],
+        ]);
+
+        $metadata = $certificate->getMetadata('name');
+
+        $this->assertEquals($metadata, 'test');
+    }
+}

--- a/tests/models/IssuerTest.php
+++ b/tests/models/IssuerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Maclof\Kubernetes\Models\Issuer;
+
+class IssuerTest extends TestCase
+{
+    public function test_get_schema()
+    {
+        $issuer = new Issuer;
+
+        $schema = trim($issuer->getSchema());
+        $fixture = trim($this->getFixture('issuers/empty.json'));
+
+        $this->assertEquals($fixture, $schema);
+    }
+
+    public function test_get_metadata()
+    {
+        $issuer = new Issuer([
+            'metadata' => [
+                'name' => 'test',
+            ],
+        ]);
+
+        $metadata = $issuer->getMetadata('name');
+
+        $this->assertEquals($metadata, 'test');
+    }
+}


### PR DESCRIPTION
Initial suport of "certmanager.k8s.io/v1alpha1" resources.

Please review my assumption, that user should access repository via same commands like in kubectl, eg. `kubectl get certificates` should be accessed via library by calling `$client->certificates()->...`.

Readme modified, added nice table, I also fixed previous PR invalid readme example.
No API Changes from user point of view.