### PR TITLE
Update Ingress support for kubernetes version 1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ $ composer require maclof/kubernetes-client
 
 ### extensions/v1beta1
 * Daemon Sets
-* Ingresses
 
 ### networking.k8s.io/v1
 * Network Policies
+
+### networking.k8s.io/v1beta1
+* Ingresses
 
 ### certmanager.k8s.io/v1alpha1
 * Certificates

--- a/src/Models/Ingress.php
+++ b/src/Models/Ingress.php
@@ -7,5 +7,5 @@ class Ingress extends Model
 	 *
 	 * @var string
 	 */
-	protected $apiVersion = 'extensions/v1beta1';
+	protected $apiVersion = 'networking.k8s.io/v1beta1';
 }

--- a/tests/fixtures/ingresses/empty.json
+++ b/tests/fixtures/ingresses/empty.json
@@ -1,4 +1,4 @@
 {
     "kind": "Ingress",
-    "apiVersion": "extensions/v1beta1"
+    "apiVersion": "networking.k8s.io/v1beta1"
 }


### PR DESCRIPTION
When I try the library with Kubernetes version 1.18 I got an error, digging up it seems that the API has changed from "extensions" to "networking.k8s.io" on this component. This should fix it. But also note that this could break apps running on older versions. Maybe it should be better to add a new branch that supports version 1.18 but I leave it to your discretion. 
Regards, and nice job with this library I used it for various Laravel apps interacting with k8s clusters.