### PR TITLE
Fix response always returns stream

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -505,13 +505,12 @@ class Client
 
 		try {
 			$response = $this->guzzleClient->request($method, $requestUri, $requestOptions);
-			$responseBody = $response->getBody();
 
-			if ($responseBody instanceof Stream) {
+			if (!empty($options['stream'])) {
 				return $response;
 			}
 
-			$responseBody = (string) $responseBody;
+			$responseBody = (string) $response->getBody();
 			$jsonResponse = json_decode($responseBody, true);
 
 			return is_array($jsonResponse) ? $jsonResponse : $responseBody;


### PR DESCRIPTION
Guzzle always returns a `Stream` for the request body, so the current implementation always returns a Stream for each call, which then causes an error where the response is expected to be an array (decoded from the son)