### PR TITLE
Added ability to use own namespace for model

### DIFF
--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -43,6 +43,14 @@ abstract class Repository
 	 */
 	protected $fieldSelector = [];
 
+
+	/**
+	 * The default class namespace of the repositories
+	 * 
+	 * @var string
+	 */
+	protected $modelClassNamespace = 'Maclof\Kubernetes\Models\\';
+
 	/**
 	 * The constructor.
 	 *
@@ -86,7 +94,7 @@ abstract class Repository
 		}
 
 		$className = str_replace('Repository', '', class_basename($this));
-		$classPath = 'Maclof\Kubernetes\Models\\' . $className;
+		$classPath = $this->modelClassNamespace . $className;
 
 		if (!class_exists($classPath)) {
 			return;


### PR DESCRIPTION
Currently only custom models with the namespace Maclof\Kubernetes\Models are possible. This pull request adds a new protected variable "modelClassNamespace" which has the current namespace as default and can be overwritten in the model which inherits the class