### PR TITLE
Use null values for labels as “any value”

### DIFF
--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -204,7 +204,7 @@ abstract class Repository
 	{
 		$parts = [];
 		foreach ($this->labelSelector as $key => $value) {
-			$parts[] = $key . '=' . $value;
+			$parts[] = null === $value ? $key : ($key . '=' . $value);
 		}
 		return implode(',', $parts);
 	}


### PR DESCRIPTION
I'd like to propose the following change:

When querying objects from the Kubernetes API, labels may be provided to filter the results. This is implemented in this library using the `Repository->setLabelSelector()` method.

The API allows for querying objects having a certain label, regardless of its value. Instead of providing `mylabel=value`, you can just pass `mylabel` to the query, which returns all objects having the label `mylabel`. To implement this, I've changed the `Repository->getLabelSelectorQuery()` method. If the label value is `null`, the label is added to the `$parts` array without the `=`.