### PR TITLE
Added applyJsonPatch function

### DIFF
--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -138,6 +138,22 @@ abstract class Repository
 		return $this->sendRequest('PATCH', '/' . $this->uri . '/' . $model->getMetadata('name'), null, $model->getSchema(), $this->namespace);
 	}
 
+	/**
+	 * Apply a json patch to a model.
+	 *
+	 * @param \Maclof\Kubernetes\Models\Model $model
+	 * @param array $model
+	 * @return array
+	 */
+	public function applyJsonPatch(Model $model, array $patch)
+	{
+		$patch = json_encode($patch);
+		
+		$this->client->setPatchType('json');
+
+		return $this->sendRequest('PATCH', '/' . $this->uri . '/' . $model->getMetadata('name'), null, $patch, $this->namespace);
+	}
+
     /**
      * Apply a model.
      *


### PR DESCRIPTION
At the moment there doesn't seem to be a way to apply a json patch object.

The applyJsonPatch() function will perform a PATCH request against the provided model with the content-type set to application/json-patch+json and the provided json patch array as the body.

Example json patch array:
```
[
    [ 'op' => 'remove', 'path' => '/metadata/labels/foo' ],
   [ 'op' => 'remove', 'path' => '/metadata/labels/bar' ]
]
```