### PR TITLE
Fix failing unit test suite, bump travis env to bionic beaver

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+# Real-Tab indents by default, width 4
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+
+# Set default charset
+[*.{yml,php,xml,json}]
+charset = utf-8
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: trusty
+dist: focal
 
 php:
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ php:
 
 before_script:
   - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+  - composer install --prefer-source --no-interaction
 
 script: vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: php
-dist: xenial
+dist: bionic
 
 php:
   - 7.1
   - 7.2
   - 7.3
   - 7.4
-  - 8.0
+#  - 8.0 # PHP 8.0 requires PHPUnit to be upgraded, which then would break earlier versions
+
+env:
+  global:
+    - XDEBUG_MODE=coverage
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: focal
+dist: xenial
 
 php:
   - 7.1

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
 	"require-dev": {
 		"phpunit/phpunit"            : "~7.0",
 		"mockery/mockery"            : "~1.2",
-		"php-coveralls/php-coveralls": "~2.0"
+		"php-coveralls/php-coveralls": "~2.0",
+		"nyholm/psr7": "^1.4"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
 	},
 	"autoload-dev": {
 		"classmap": [
-			"tests/TestCase.php"
+			"tests/TestCase.php",
+			"tests/helpers/HttpMethodsMockClient.php"
 		]
 	},
 	"minimum-stability": "dev",

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,6 +1,7 @@
 <?php namespace Maclof\Kubernetes;
 
 use Exception;
+use Http\Client\Common\HttpMethodsClientInterface;
 use InvalidArgumentException;
 use BadMethodCallException;
 use Symfony\Component\Yaml\Yaml;
@@ -116,7 +117,7 @@ class Client
 	/**
 	 * The http client.
 	 *
-	 * @var \Http\Client\Common\HttpMethodsClient
+	 * @var \Http\Client\Common\HttpMethodsClientInterface
 	 */
 	protected $httpClient;
 
@@ -416,7 +417,7 @@ class Client
 		}
 
 		try {
-			$headers = $method == 'PATCH' ? $this->patchHeaders : [];
+			$headers = $method === 'PATCH' ? $this->patchHeaders : [];
 
 			if ($this->token) {
 				$token = $this->token;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,73 +1,96 @@
 <?php
 
+use Http\Client\Common\HttpMethodsClient;
 use Maclof\Kubernetes\Client;
-use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\Message\RequestInterface;
-use GuzzleHttp\Message\ResponseInterface;
+use Maclof\Kubernetes\Collections\PodCollection;
+use Maclof\Kubernetes\Models\Pod;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\Response;
+use Psr\Http\Client\ClientInterface;
 
 class ClientTest extends TestCase
 {
-	protected function getClient(GuzzleClient $guzzleClient = null)
+	public function testSendRequestJsonParsesResponse()
 	{
-		return new Client(
-			[
-				'master' => '',
+		$httpClientProp = new ReflectionProperty(Client::class, 'httpClient');
+		$httpClientProp->setAccessible(true);
+		$client = new Client([
+			'master' => 'https://api.example.com',
+		]);
+
+		$mockClientInterface = $this->getMockBuilder(ClientInterface::class)
+			->setMethods(['sendRequest'])
+			->getMock();
+
+		$jsonBody = json_encode([
+			'message' => 'Hello world',
+		]);
+
+		$response = new Response(200, [], $jsonBody);
+
+		$mockClientInterface->expects($this->once())
+			->method('sendRequest')
+			->withAnyParameters()
+			->willReturn($response);
+
+		$httpClient = new HttpMethodsClient($mockClientInterface, new Psr17Factory());
+
+		$httpClientProp->setValue($client, $httpClient);
+
+		$result = $client->sendRequest('GET', '/v1/poddy/');
+
+		$this->assertSame([
+			'message' => 'Hello world',
+		], $result);
+	}
+
+	private function setMockHttpResponse(
+		Client $client,
+		array $mockResponse,
+		array $expectedSendArgs,
+		int $respStatusCode = 200,
+		array $respHeaders = []
+	) {
+		$httpClientProp = new ReflectionProperty(Client::class, 'httpClient');
+		$httpClientProp->setAccessible(true);
+
+		$mockHttpMethodsClient = $this->getMockBuilder(HttpMethodsMockClient::class)
+			->setMethods(['send'])
+			->getMock();
+
+		$jsonBody = json_encode($mockResponse);
+
+		$response = new Response($respStatusCode, $respHeaders, $jsonBody);
+
+		$mockHttpMethodsClient->expects($this->once())
+			->method('send')
+			->with(...$expectedSendArgs)
+			->willReturn($response);
+
+		$httpClientProp->setValue($client, $mockHttpMethodsClient);
+	}
+
+	public function testGetPodsFromApi()
+	{
+		$client = new Client();
+
+		$jsonBody = [
+			'items' => [
+				[],
+				[],
+				[],
 			],
-			$guzzleClient
-		);
+		];
+
+		$this->setMockHttpResponse($client, $jsonBody, ['GET', '/api/' . $this->apiVersion . '/namespaces/' . $this->namespace . '/pods']);
+
+		$result = $client->pods()->find();
+
+		$this->assertInstanceOf(PodCollection::class, $result);
+
+		$this->assertSame(3, $result->count());
+
+		$pod1 = $result->first();
+		$this->assertInstanceOf(Pod::class, $pod1);
 	}
-
-	protected function getMockGuzzleCLient(RequestInterface $guzzleRequest = null, ResponseInterface $guzzleResponse = null)
-	{
-		$mockGuzzleClient = Mockery::mock('GuzzleHttp\Client');
-
-		if ($guzzleRequest && $guzzleResponse) {
-			$mockGuzzleClient->shouldReceive('send')->with($guzzleRequest)->andReturn($guzzleResponse);
-		}
-
-		return $mockGuzzleClient;
-	}
-
-	protected function getMockGuzzleRequest()
-	{
-		$mockGuzzleRequest = Mockery::mock('GuzzleHttp\Message\RequestInterface');
-
-		return $mockGuzzleRequest;
-	}
-
-	protected function getMockGuzzleResponse(array $response = array())
-	{
-		$mockGuzzleResponse = Mockery::mock('GuzzleHttp\Message\ResponseInterface');
-		$mockGuzzleResponse->shouldReceive('json')->with()->andReturn($response);
-
-		return $mockGuzzleResponse;
-	}
-
-	public function test_get_guzzle_client()
-	{
-		$client = $this->getClient();
-
-		$this->assertInstanceOf('GuzzleHttp\Client', $client->getGuzzleClient());
-	}
-
-	// public function test_get_pods()
-	// {
-	// 	$request = $this->getMockGuzzleRequest();
-	// 	$response = $this->getMockGuzzleResponse([
-	// 		'items' => [
-	// 			[],
-	// 			[],
-	// 			[],
-	// 		],
-	// 	]);
-	// 	$mockGuzzleClient = $this->getMockGuzzleCLient($request, $response);
-	// 	$mockGuzzleClient->shouldReceive('createRequest')
-	// 		->with('GET', '/api/' . $this->apiVersion . '/namespaces/' . $this->namespace . '/pods', ['query' => [], 'body' => null])
-	// 		->andReturn($request);
-
-	// 	$client = $this->getClient($mockGuzzleClient);
-	// 	$pods = $client->pods()->find();
-
-	// 	$this->assertInstanceOf('Maclof\Kubernetes\Collections\PodCollection', $pods);
-	// }
 }

--- a/tests/helpers/HttpMethodsMockClient.php
+++ b/tests/helpers/HttpMethodsMockClient.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Use this class in unit tests to mock more easily
+ */
+class HttpMethodsMockClient implements \Http\Client\Common\HttpMethodsClientInterface
+{
+	public function sendRequest(\Psr\Http\Message\RequestInterface $request): \Psr\Http\Message\ResponseInterface
+	{
+		return new \Nyholm\Psr7\Response(200, [], 'dummy-mock');
+	}
+
+	public function get($uri, array $headers = []): \Psr\Http\Message\ResponseInterface
+	{
+		return new \Nyholm\Psr7\Response(200, [], 'dummy-mock');
+	}
+
+	public function head($uri, array $headers = []): \Psr\Http\Message\ResponseInterface
+	{
+		return new \Nyholm\Psr7\Response(200, [], 'dummy-mock');
+	}
+
+	public function trace($uri, array $headers = []): \Psr\Http\Message\ResponseInterface
+	{
+		return new \Nyholm\Psr7\Response(200, [], 'dummy-mock');
+	}
+
+	public function post($uri, array $headers = [], $body = null): \Psr\Http\Message\ResponseInterface
+	{
+		return new \Nyholm\Psr7\Response(200, [], 'dummy-mock');
+	}
+
+	public function put($uri, array $headers = [], $body = null): \Psr\Http\Message\ResponseInterface
+	{
+		return new \Nyholm\Psr7\Response(200, [], 'dummy-mock');
+	}
+
+	public function patch($uri, array $headers = [], $body = null): \Psr\Http\Message\ResponseInterface
+	{
+		return new \Nyholm\Psr7\Response(200, [], 'dummy-mock');
+	}
+
+	public function delete($uri, array $headers = [], $body = null): \Psr\Http\Message\ResponseInterface
+	{
+		return new \Nyholm\Psr7\Response(200, [], 'dummy-mock');
+	}
+
+	public function options($uri, array $headers = [], $body = null): \Psr\Http\Message\ResponseInterface
+	{
+		return new \Nyholm\Psr7\Response(200, [], 'dummy-mock');
+	}
+
+	public function send(string $method, $uri, array $headers = [], $body = null): \Psr\Http\Message\ResponseInterface
+	{
+		return new \Nyholm\Psr7\Response(200, [], 'dummy-mock');
+	}
+}


### PR DESCRIPTION
Tests have been failing since... I'm not sure but it has something to do with a Guzzle Http change. Here in ClientTest I noticed also that `test_get_pods` was commented out, so I redid that test with the fixes so it would pass.

I noticed the repo is set up to use travis-ci.com, so perhaps before it was using travis-ci.org, which was turned off, then tests broke, but then the repo was migrated to travis-ci.com (a good thing).

I also added `8.0` to the test matrix to see if tests would pass on PHP 8.0 as well.

I also composer required --dev `nyholm/psr7` since I'm using those concrete implementations in the unit tests. The repo already had this package through some other dependency, but it's good practice to explicitly require if being used somewhere.

Finally, I added an `.editorconfig` to specify some basic indenting/encoding rules on what seems to be this repo's standards.