### PR TITLE
Fix Issue 81, some method call sites

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -402,7 +402,7 @@ class Client
 	 */
 	public function sendRequest($method, $uri, $query = [], $body = null, $namespace = true, $apiVersion = null, array $requestOptions = [])
 	{
-		$baseUri = $apiVersion ? 'apis/' . $apiVersion : 'api/' . $this->apiVersion;
+		$baseUri = $apiVersion ? 'api/' . $apiVersion : 'api/' . $this->apiVersion;
 		if ($namespace) {
 			$baseUri .= '/namespaces/' . $this->namespace;
 		}
@@ -445,7 +445,7 @@ class Client
 				throw new ApiServerException("Authentication Exception: " . $msg, $response->getStatusCode());
 			}
 
-			if (!empty($options['stream'])) {
+			if (isset($requestOptions['stream']) && $requestOptions['stream'] === true) {
 				return $response;
 			}
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -445,7 +445,7 @@ class Client
 				throw new ApiServerException("Authentication Exception: " . $msg, $response->getStatusCode());
 			}
 
-			if (isset($requestOptions['stream']) && $requestOptions['stream'] === true) {
+			if (isset($query['stream']) && $query['stream'] === true) {
 				return $response;
 			}
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -402,7 +402,7 @@ class Client
 	 */
 	public function sendRequest($method, $uri, $query = [], $body = null, $namespace = true, $apiVersion = null, array $requestOptions = [])
 	{
-		$baseUri = $apiVersion ? 'api/' . $apiVersion : 'api/' . $this->apiVersion;
+		$baseUri = $apiVersion ? ('apis/' . $apiVersion) : ('api/' . $this->apiVersion);
 		if ($namespace) {
 			$baseUri .= '/namespaces/' . $this->namespace;
 		}

--- a/src/Client.php
+++ b/src/Client.php
@@ -445,7 +445,7 @@ class Client
 				throw new ApiServerException("Authentication Exception: " . $msg, $response->getStatusCode());
 			}
 
-			if (isset($query['stream']) && $query['stream'] === true) {
+			if (isset($requestOptions['stream']) && $requestOptions['stream'] === true) {
 				return $response;
 			}
 

--- a/src/Repositories/NodeRepository.php
+++ b/src/Repositories/NodeRepository.php
@@ -14,8 +14,7 @@ class NodeRepository extends Repository
 
 	public function proxy($node, $method, $proxy_uri, array $options = [])
 	{
-		$response = $this->client->sendRequest($method, '/' . $this->uri . '/' . $node->getMetadata('name') . '/proxy/' . $proxy_uri, $options, [], $this->namespace);
-
+		$response = $this->client->sendRequest($method, '/' . $this->uri . '/' . $node->getMetadata('name') . '/proxy/' . $proxy_uri, [], [], $this->namespace, $this->getApiVersion(), $options);
 		return $response;
 	}
 }

--- a/src/Repositories/NodeRepository.php
+++ b/src/Repositories/NodeRepository.php
@@ -12,9 +12,9 @@ class NodeRepository extends Repository
 		return new NodeCollection($response['items']);
 	}
 
-	public function proxy($node, $method, $proxy_uri, array $options = [])
+	public function proxy($node, $method, $proxy_uri, array $queryParams = [])
 	{
-		$response = $this->client->sendRequest($method, '/' . $this->uri . '/' . $node->getMetadata('name') . '/proxy/' . $proxy_uri, [], [], $this->namespace, $this->getApiVersion(), $options);
+		$response = $this->client->sendRequest($method, '/' . $this->uri . '/' . $node->getMetadata('name') . '/proxy/' . $proxy_uri, $queryParams, [], $this->namespace);
 		return $response;
 	}
 }

--- a/src/Repositories/PodRepository.php
+++ b/src/Repositories/PodRepository.php
@@ -21,7 +21,7 @@ class PodRepository extends Repository
 	 */
 	public function logs(Pod $pod, array $options = [])
 	{
-		$response = $this->client->sendRequest('GET', '/' . $this->uri . '/' . $pod->getMetadata('name') . '/log', $options);
+		$response = $this->client->sendRequest('GET', '/' . $this->uri . '/' . $pod->getMetadata('name') . '/log', [], null, $this->namespace, $this->getApiVersion(), $options);
 
 		return $response;
 	}
@@ -35,7 +35,7 @@ class PodRepository extends Repository
 	 */
 	public function exec(Pod $pod, array $options = [])
 	{
-		$response = $this->client->sendRequest('POST', '/' . $this->uri . '/' . $pod->getMetadata('name') . '/exec', $options);
+		$response = $this->client->sendRequest('POST', '/' . $this->uri . '/' . $pod->getMetadata('name') . '/exec', [], null, $this->namespace, $this->getApiVersion(), $options);
 
 		return $response;
 	}

--- a/src/Repositories/PodRepository.php
+++ b/src/Repositories/PodRepository.php
@@ -16,13 +16,12 @@ class PodRepository extends Repository
 	 * Get the logs for a pod.
 	 *
 	 * @param  \Maclof\Kubernetes\Models\Pod $pod
-	 * @param  array $options
+	 * @param  array $queryParams
 	 * @return string
 	 */
-	public function logs(Pod $pod, array $options = [])
+	public function logs(Pod $pod, array $queryParams = [])
 	{
-		$response = $this->client->sendRequest('GET', '/' . $this->uri . '/' . $pod->getMetadata('name') . '/log', [], null, $this->namespace, $this->getApiVersion(), $options);
-
+		$response = $this->client->sendRequest('GET', '/' . $this->uri . '/' . $pod->getMetadata('name') . '/log', $queryParams);
 		return $response;
 	}
 	
@@ -30,13 +29,12 @@ class PodRepository extends Repository
 	 * Execute a command on a pod.
 	 *
 	 * @param  \Maclof\Kubernetes\Models\Pod $pod
-	 * @param  array $options
+	 * @param  array $queryParams
 	 * @return string
 	 */
-	public function exec(Pod $pod, array $options = [])
+	public function exec(Pod $pod, array $queryParams = [])
 	{
-		$response = $this->client->sendRequest('POST', '/' . $this->uri . '/' . $pod->getMetadata('name') . '/exec', [], null, $this->namespace, $this->getApiVersion(), $options);
-
+		$response = $this->client->sendRequest('POST', '/' . $this->uri . '/' . $pod->getMetadata('name') . '/exec', $queryParams);
 		return $response;
 	}
 }

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -89,7 +89,7 @@ abstract class Repository
 	protected function sendRequest($method, $uri, $query = [], $body = [], $namespace = true, array $requestOptions = [])
 	{
 		$apiVersion = $this->getApiVersion();
-		if ($apiVersion == 'v1') {
+		if ($apiVersion === 'v1') {
 			$apiVersion = null;
 		}
 
@@ -99,7 +99,7 @@ abstract class Repository
 	/**
 	 * Get the api version from the model.
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	protected function getApiVersion()
 	{
@@ -111,7 +111,7 @@ abstract class Repository
 		$classPath = $this->modelClassNamespace . $className;
 
 		if (!class_exists($classPath)) {
-			return;
+			return null;
 		}
 
 		$this->apiVersion = (new $classPath)->getApiVersion();


### PR DESCRIPTION
This should fix Issue [81](https://github.com/maclof/kubernetes-client/issues/81), but please don't merge yet. I'd like to test it more.

https://github.com/maclof/kubernetes-client/issues/81

Interestingly due to use of `empty()`, a non-existent variable was ignored so if `watch => true` was passed into `$requestOptions` it would have never been checked.

I also update some method calls to `sendRequest` which seemed to be the intention, but I'm not sure. Before, it was passing `$options` into the `$query` parameter, but I'm guessing it should have been passed as `$requestOptions`.
