### PR TITLE
#98 Raise PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: php
 dist: bionic
 
 php:
-  - 7.1
-  - 7.2
-  - 7.3
   - 7.4
 #  - 8.0 # PHP 8.0 requires PHPUnit to be upgraded, which then would break earlier versions
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	],
 	"license" : "MIT",
 	"require": {
-		"php"                   : "^7.1|^8.0",
+		"php"                   : "^7.4|^8.0",
 		"php-http/client-common": "^2.0",
 		"php-http/socket-client": "^2.0",
 		"php-http/discovery"    : "^1.0",

--- a/src/Client.php
+++ b/src/Client.php
@@ -69,57 +69,41 @@ class Client
 {
 	/**
 	 * The api version.
-	 *
-	 * @var string
 	 */
 	protected string $apiVersion = 'v1';
 
 	/**
 	 * The address of the master server.
-	 *
-	 * @var string|null
 	 */
 	protected ?string $master = null;
 
 	/**
 	 * The servide account token.
-	 *
-	 * @var string
 	 */
 	protected ?string $token = null;
 
 	/**
 	 * The username for basic auth.
-	 *
-	 * @var string
 	 */
 	protected ?string $username = null;
 
 	/**
 	 * The password for basic auth.
-	 *
-	 * @var string
 	 */
 	protected ?string $password = null;
 
 	/**
 	 * The namespace.
-	 *
-	 * @var string
 	 */
 	protected string $namespace = 'default';
 
 	/**
 	 * The http client.
-	 *
-	 * @var \Http\Client\Common\HttpMethodsClientInterface
 	 */
 	protected HttpMethodsClientInterface $httpClient;
 
 	/**
 	 * The exec channels for result messages.
-	 *
-	 * @var array
 	 */
 	protected array $execChannels = [
 		'stdin',
@@ -131,22 +115,16 @@ class Client
 
 	/**
 	 * The repository class registry.
-	 *
-	 * @var RepositoryRegistry
 	 */
 	protected RepositoryRegistry $classRegistry;
 
 	/**
 	 * The class instances.
-	 *
-	 * @var array
 	 */
 	protected array $classInstances = [];
 
 	/**
 	 * header for patch.
-	 *
-	 * @var array
 	 */
 	protected array $patchHeaders = ['Content-Type' => 'application/strategic-merge-patch+json'];
 
@@ -160,11 +138,6 @@ class Client
 
 	/**
 	 * The constructor.
-	 *
-	 * @param array $options
-	 * @param \Maclof\Kubernetes\RepositoryRegistry|null $repositoryRegistry
-	 * @param ClientInterface|null $httpClient Some client implementing PSR HTTP ClientInterface
-	 * @param \Http\Message\RequestFactory $httpRequestFactory
 	 */
 	public function __construct(array $options = [], RepositoryRegistry $repositoryRegistry = null, ClientInterface $httpClient = null, HttpRequestFactory $httpRequestFactory = null)
 	{
@@ -178,9 +151,6 @@ class Client
 
 	/**
 	 * Set the options.
-	 *
-	 * @param  array $options
-	 * @param  bool  $reset
 	 */
 	public function setOptions(array $options, bool $reset = false): void
 	{
@@ -214,8 +184,6 @@ class Client
 	 * Parse a kubeconfig.
 	 * 
 	 * @param  string|array $content Mixed type, based on the second input argument
-	 * @param  string $contentType
-	 * @return array
 	 * @throws \InvalidArgumentException
 	 */
 	public static function parseKubeconfig($content, string $contentType = 'yaml'): array
@@ -337,8 +305,6 @@ class Client
 	/**
 	 * Parse a kubeconfig file.
 	 * 
-	 * @param  string $filePath
-	 * @return array
 	 * @throws \InvalidArgumentException
 	 */
 	public static function parseKubeconfigFile(string $filePath): array
@@ -352,10 +318,6 @@ class Client
 
 	/**
 	 * Get a temp file path for some content.
-	 *
-	 * @param  string $fileName
-	 * @param  string $fileContent
-	 * @return string
 	 */
 	protected static function getTempFilePath(string $fileName, string $fileContent): string
 	{
@@ -372,8 +334,6 @@ class Client
 
 	/**
 	 * Set namespace.
-	 *
-	 * @param string $namespace
 	 */
 	public function setNamespace(string $namespace): void
 	{
@@ -382,8 +342,6 @@ class Client
 
 	/**
 	 * Set patch header
-	 *
-	 * @param string patch type
 	 */
 	public function setPatchType(string $patchType = "strategic"): void
 	{
@@ -399,13 +357,7 @@ class Client
 	/**
 	 * Send a request.
 	 *
-	 * @param  string  $method
-	 * @param  string  $uri
-	 * @param  array   $query
-	 * @param  mixed   $body
-	 * @param  boolean $namespace
-	 * @param  string  $apiVersion
-	 * @param  array   $requestOptions
+	 * @param  mixed $body
 	 * @return mixed
 	 * @throws \Maclof\Kubernetes\Exceptions\BadRequestException
 	 */
@@ -481,9 +433,6 @@ class Client
 
 	/**
 	 * Check if an upgrade request is required.
-	 *
-	 * @param  array $response
-	 * @return boolean
 	 */
 	protected function isUpgradeRequestRequired(array $response): bool
 	{
@@ -492,10 +441,6 @@ class Client
 
 	/**
 	 * Send an upgrade request and return any response messages.
-	 *
-	 * @param  string $requestUri
-	 * @param  array  $query
-	 * @return array
 	 */
 	protected function sendUpgradeRequest(string $requestUri, array $query): array
 	{
@@ -577,9 +522,6 @@ class Client
 
 	/**
 	 * Parse an array of query params.
-	 *
-	 * @param  array $query
-	 * @return array
 	 */
 	protected function parseQueryParams(array $query): array
 	{
@@ -612,8 +554,6 @@ class Client
 	
 	/**
 	 * Check the version.
-	 *
-	 * @return array
 	 */
 	public function version(): array
 	{
@@ -623,8 +563,6 @@ class Client
 	/**
 	 * Magic call method to grab a class instance.
 	 *
-	 * @param  string $name
-	 * @param  array  $args
 	 * @return \stdClass
 	 * @throws \BadMethodCallException
 	 */

--- a/src/Client.php
+++ b/src/Client.php
@@ -361,6 +361,7 @@ class Client
 	 * @return mixed
 	 * @throws \Maclof\Kubernetes\Exceptions\BadRequestException
 	 */
+	#[\ReturnTypeWillChange]
 	public function sendRequest(string $method, string $uri, array $query = [], $body = null, bool $namespace = true, string $apiVersion = null, array $requestOptions = [])
 	{
 		$baseUri = $apiVersion ? ('apis/' . $apiVersion) : ('api/' . $this->apiVersion);

--- a/src/Collections/CertificateCollection.php
+++ b/src/Collections/CertificateCollection.php
@@ -6,8 +6,6 @@ class CertificateCollection extends Collection
 {
     /**
      * The constructor.
-     *
-     * @param array $items
      */
     public function __construct(array $items)
     {
@@ -16,9 +14,6 @@ class CertificateCollection extends Collection
 
     /**
      * Get an array of certificates.
-     *
-     * @param  array $items
-     * @return array
      */
     protected function getCertificates(array $items): array
     {

--- a/src/Collections/CertificateCollection.php
+++ b/src/Collections/CertificateCollection.php
@@ -20,7 +20,7 @@ class CertificateCollection extends Collection
      * @param  array $items
      * @return array
      */
-    protected function getCertificates(array $items)
+    protected function getCertificates(array $items): array
     {
         foreach ($items as &$item) {
             if ($item instanceof Certificate) {

--- a/src/Collections/ConfigMapCollection.php
+++ b/src/Collections/ConfigMapCollection.php
@@ -6,8 +6,6 @@ class ConfigMapCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class ConfigMapCollection extends Collection
 
 	/**
 	 * Get an array of config maps.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getConfigMaps(array $items): array
 	{

--- a/src/Collections/ConfigMapCollection.php
+++ b/src/Collections/ConfigMapCollection.php
@@ -20,7 +20,7 @@ class ConfigMapCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getConfigMaps(array $items)
+	protected function getConfigMaps(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof ConfigMap) {

--- a/src/Collections/CronJobCollection.php
+++ b/src/Collections/CronJobCollection.php
@@ -20,7 +20,7 @@ class CronJobCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getCronJobs(array $items)
+	protected function getCronJobs(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof CronJob) {

--- a/src/Collections/CronJobCollection.php
+++ b/src/Collections/CronJobCollection.php
@@ -6,8 +6,6 @@ class CronJobCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class CronJobCollection extends Collection
 
 	/**
 	 * Get an array of cron jobs.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getCronJobs(array $items): array
 	{

--- a/src/Collections/DaemonSetCollection.php
+++ b/src/Collections/DaemonSetCollection.php
@@ -20,7 +20,7 @@ class DaemonSetCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getDaemonSets(array $items)
+	protected function getDaemonSets(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof DaemonSet) {

--- a/src/Collections/DaemonSetCollection.php
+++ b/src/Collections/DaemonSetCollection.php
@@ -6,8 +6,6 @@ class DaemonSetCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class DaemonSetCollection extends Collection
 
 	/**
 	 * Get an array of daemon sets.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getDaemonSets(array $items): array
 	{

--- a/src/Collections/DeploymentCollection.php
+++ b/src/Collections/DeploymentCollection.php
@@ -20,7 +20,7 @@ class DeploymentCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getDeployments(array $items)
+	protected function getDeployments(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof Deployment) {

--- a/src/Collections/DeploymentCollection.php
+++ b/src/Collections/DeploymentCollection.php
@@ -6,8 +6,6 @@ class DeploymentCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class DeploymentCollection extends Collection
 
 	/**
 	 * Get an array of deployments.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getDeployments(array $items): array
 	{

--- a/src/Collections/EndpointCollection.php
+++ b/src/Collections/EndpointCollection.php
@@ -20,7 +20,7 @@ class EndpointCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getEndpoints(array $items)
+	protected function getEndpoints(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof Endpoint) {

--- a/src/Collections/EndpointCollection.php
+++ b/src/Collections/EndpointCollection.php
@@ -6,8 +6,6 @@ class EndpointCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class EndpointCollection extends Collection
 
 	/**
 	 * Get an array of nodes.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getEndpoints(array $items): array
 	{

--- a/src/Collections/EventCollection.php
+++ b/src/Collections/EventCollection.php
@@ -20,7 +20,7 @@ class EventCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getEvents(array $items)
+	protected function getEvents(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof Event) {

--- a/src/Collections/EventCollection.php
+++ b/src/Collections/EventCollection.php
@@ -6,8 +6,6 @@ class EventCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class EventCollection extends Collection
 
 	/**
 	 * Get an array of nodes.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getEvents(array $items): array
 	{

--- a/src/Collections/HorizontalPodAutoscalerCollection.php
+++ b/src/Collections/HorizontalPodAutoscalerCollection.php
@@ -20,7 +20,7 @@ class HorizontalPodAutoscalerCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getHorizontalPodAutoscalers(array $items)
+	protected function getHorizontalPodAutoscalers(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof HorizontalPodAutoscaler) {

--- a/src/Collections/HorizontalPodAutoscalerCollection.php
+++ b/src/Collections/HorizontalPodAutoscalerCollection.php
@@ -6,8 +6,6 @@ class HorizontalPodAutoscalerCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class HorizontalPodAutoscalerCollection extends Collection
 
 	/**
 	 * Get an array of autoscalers.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getHorizontalPodAutoscalers(array $items): array
 	{

--- a/src/Collections/IngressCollection.php
+++ b/src/Collections/IngressCollection.php
@@ -6,8 +6,6 @@ class IngressCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class IngressCollection extends Collection
 
 	/**
 	 * Get an array of Ingresses.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getIngresses(array $items): array
 	{

--- a/src/Collections/IngressCollection.php
+++ b/src/Collections/IngressCollection.php
@@ -20,7 +20,7 @@ class IngressCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getIngresses(array $items)
+	protected function getIngresses(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof Ingress) {

--- a/src/Collections/IssuerCollection.php
+++ b/src/Collections/IssuerCollection.php
@@ -6,8 +6,6 @@ class IssuerCollection extends Collection
 {
     /**
      * The constructor.
-     *
-     * @param array $items
      */
     public function __construct(array $items)
     {
@@ -16,9 +14,6 @@ class IssuerCollection extends Collection
 
     /**
      * Get an array of certificate issuers.
-     *
-     * @param  array $items
-     * @return array
      */
     protected function getIssuers(array $items): array
     {

--- a/src/Collections/IssuerCollection.php
+++ b/src/Collections/IssuerCollection.php
@@ -20,7 +20,7 @@ class IssuerCollection extends Collection
      * @param  array $items
      * @return array
      */
-    protected function getIssuers(array $items)
+    protected function getIssuers(array $items): array
     {
         foreach ($items as &$item) {
             if ($item instanceof Issuer) {

--- a/src/Collections/JobCollection.php
+++ b/src/Collections/JobCollection.php
@@ -20,7 +20,7 @@ class JobCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getJobs(array $items)
+	protected function getJobs(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof Job) {

--- a/src/Collections/JobCollection.php
+++ b/src/Collections/JobCollection.php
@@ -6,8 +6,6 @@ class JobCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class JobCollection extends Collection
 
 	/**
 	 * Get an array of jobs.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getJobs(array $items): array
 	{

--- a/src/Collections/NamespaceCollection.php
+++ b/src/Collections/NamespaceCollection.php
@@ -20,7 +20,7 @@ class NamespaceCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getNamespaces(array $items)
+	protected function getNamespaces(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof NamespaceModel) {

--- a/src/Collections/NamespaceCollection.php
+++ b/src/Collections/NamespaceCollection.php
@@ -6,8 +6,6 @@ class NamespaceCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class NamespaceCollection extends Collection
 
 	/**
 	 * Get an array of Namespaces.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getNamespaces(array $items): array
 	{

--- a/src/Collections/NetworkPolicyCollection.php
+++ b/src/Collections/NetworkPolicyCollection.php
@@ -20,7 +20,7 @@ class NetworkPolicyCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getPolicies(array $items)
+	protected function getPolicies(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof NetworkPolicy) {

--- a/src/Collections/NetworkPolicyCollection.php
+++ b/src/Collections/NetworkPolicyCollection.php
@@ -6,8 +6,6 @@ class NetworkPolicyCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class NetworkPolicyCollection extends Collection
 
 	/**
 	 * Get an array of network policies.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getPolicies(array $items): array
 	{

--- a/src/Collections/NodeCollection.php
+++ b/src/Collections/NodeCollection.php
@@ -20,7 +20,7 @@ class NodeCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getNodes(array $items)
+	protected function getNodes(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof Node) {

--- a/src/Collections/NodeCollection.php
+++ b/src/Collections/NodeCollection.php
@@ -6,8 +6,6 @@ class NodeCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class NodeCollection extends Collection
 
 	/**
 	 * Get an array of nodes.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getNodes(array $items): array
 	{

--- a/src/Collections/PersistentVolumeClaimCollection.php
+++ b/src/Collections/PersistentVolumeClaimCollection.php
@@ -20,7 +20,7 @@ class PersistentVolumeClaimCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getPersistentVolumeClaims(array $items)
+	protected function getPersistentVolumeClaims(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof PersistentVolumeClaim) {

--- a/src/Collections/PersistentVolumeClaimCollection.php
+++ b/src/Collections/PersistentVolumeClaimCollection.php
@@ -6,8 +6,6 @@ class PersistentVolumeClaimCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class PersistentVolumeClaimCollection extends Collection
 
 	/**
 	 * Get an array of persistent volume claims.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getPersistentVolumeClaims(array $items): array
 	{

--- a/src/Collections/PersistentVolumeCollection.php
+++ b/src/Collections/PersistentVolumeCollection.php
@@ -7,8 +7,6 @@ class PersistentVolumeCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -17,9 +15,6 @@ class PersistentVolumeCollection extends Collection
 
 	/**
 	 * Get an array of persistent volumes.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getPersistentVolumes(array $items): array
 	{

--- a/src/Collections/PersistentVolumeCollection.php
+++ b/src/Collections/PersistentVolumeCollection.php
@@ -21,7 +21,7 @@ class PersistentVolumeCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getPersistentVolumes(array $items)
+	protected function getPersistentVolumes(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof PersistentVolume) {

--- a/src/Collections/PodCollection.php
+++ b/src/Collections/PodCollection.php
@@ -20,7 +20,7 @@ class PodCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getPods(array $items)
+	protected function getPods(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof Pod) {

--- a/src/Collections/PodCollection.php
+++ b/src/Collections/PodCollection.php
@@ -6,8 +6,6 @@ class PodCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class PodCollection extends Collection
 
 	/**
 	 * Get an array of pods.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getPods(array $items): array
 	{

--- a/src/Collections/QuotaCollection.php
+++ b/src/Collections/QuotaCollection.php
@@ -20,7 +20,7 @@ class QuotaCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getQuotas(array $items)
+	protected function getQuotas(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof QuotaModel) {

--- a/src/Collections/QuotaCollection.php
+++ b/src/Collections/QuotaCollection.php
@@ -6,8 +6,6 @@ class QuotaCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class QuotaCollection extends Collection
 
 	/**
 	 * Get an array of Namespaces.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getQuotas(array $items): array
 	{

--- a/src/Collections/ReplicaSetCollection.php
+++ b/src/Collections/ReplicaSetCollection.php
@@ -20,7 +20,7 @@ class ReplicaSetCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getReplicaSets(array $items)
+	protected function getReplicaSets(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof ReplicaSet) {

--- a/src/Collections/ReplicaSetCollection.php
+++ b/src/Collections/ReplicaSetCollection.php
@@ -6,8 +6,6 @@ class ReplicaSetCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class ReplicaSetCollection extends Collection
 
 	/**
 	 * Get an array of replication sets.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getReplicaSets(array $items): array
 	{

--- a/src/Collections/ReplicationControllerCollection.php
+++ b/src/Collections/ReplicationControllerCollection.php
@@ -6,8 +6,6 @@ class ReplicationControllerCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class ReplicationControllerCollection extends Collection
 
 	/**
 	 * Get an array of replication controllers.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getReplicationControllers(array $items): array
 	{

--- a/src/Collections/ReplicationControllerCollection.php
+++ b/src/Collections/ReplicationControllerCollection.php
@@ -20,7 +20,7 @@ class ReplicationControllerCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getReplicationControllers(array $items)
+	protected function getReplicationControllers(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof ReplicationController) {

--- a/src/Collections/SecretCollection.php
+++ b/src/Collections/SecretCollection.php
@@ -6,8 +6,6 @@ class SecretCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class SecretCollection extends Collection
 
 	/**
 	 * Get an array of secrets.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getSecrets(array $items): array
 	{

--- a/src/Collections/SecretCollection.php
+++ b/src/Collections/SecretCollection.php
@@ -20,7 +20,7 @@ class SecretCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getSecrets(array $items)
+	protected function getSecrets(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof Secret) {

--- a/src/Collections/ServiceCollection.php
+++ b/src/Collections/ServiceCollection.php
@@ -20,7 +20,7 @@ class ServiceCollection extends Collection
 	 * @param  array $items
 	 * @return array
 	 */
-	protected function getServices(array $items)
+	protected function getServices(array $items): array
 	{
 		foreach ($items as &$item) {
 			if ($item instanceof Service) {

--- a/src/Collections/ServiceCollection.php
+++ b/src/Collections/ServiceCollection.php
@@ -6,8 +6,6 @@ class ServiceCollection extends Collection
 {
 	/**
 	 * The constructor.
-	 *
-	 * @param array $items
 	 */
 	public function __construct(array $items)
 	{
@@ -16,9 +14,6 @@ class ServiceCollection extends Collection
 
 	/**
 	 * Get an array of services.
-	 *
-	 * @param  array $items
-	 * @return array
 	 */
 	protected function getServices(array $items): array
 	{

--- a/src/Models/Certificate.php
+++ b/src/Models/Certificate.php
@@ -3,6 +3,6 @@
 class Certificate extends Model
 {
 
-    protected $apiVersion = 'certmanager.k8s.io/v1alpha1';
+    protected string $apiVersion = 'certmanager.k8s.io/v1alpha1';
 
 }

--- a/src/Models/CronJob.php
+++ b/src/Models/CronJob.php
@@ -4,8 +4,6 @@ class CronJob extends Model
 {
 	/**
 	 * The api version.
-	 *
-	 * @var string
 	 */
 	protected string $apiVersion = 'batch/v1beta1';
 }

--- a/src/Models/CronJob.php
+++ b/src/Models/CronJob.php
@@ -7,5 +7,5 @@ class CronJob extends Model
 	 *
 	 * @var string
 	 */
-	protected $apiVersion = 'batch/v1beta1';
+	protected string $apiVersion = 'batch/v1beta1';
 }

--- a/src/Models/DaemonSet.php
+++ b/src/Models/DaemonSet.php
@@ -7,5 +7,5 @@ class DaemonSet extends Model
 	 *
 	 * @var string
 	 */
-	protected $apiVersion = 'extensions/v1beta1';
+	protected string $apiVersion = 'extensions/v1beta1';
 }

--- a/src/Models/DaemonSet.php
+++ b/src/Models/DaemonSet.php
@@ -4,8 +4,6 @@ class DaemonSet extends Model
 {
 	/**
 	 * The api version.
-	 *
-	 * @var string
 	 */
 	protected string $apiVersion = 'extensions/v1beta1';
 }

--- a/src/Models/Deployment.php
+++ b/src/Models/Deployment.php
@@ -4,8 +4,6 @@ class Deployment extends Model
 {
 	/**
 	 * The api version.
-	 *
-	 * @var string
 	 */
 	protected string $apiVersion = 'apps/v1';
 }

--- a/src/Models/Deployment.php
+++ b/src/Models/Deployment.php
@@ -7,5 +7,5 @@ class Deployment extends Model
 	 *
 	 * @var string
 	 */
-	protected $apiVersion = 'apps/v1';
+	protected string $apiVersion = 'apps/v1';
 }

--- a/src/Models/Endpoint.php
+++ b/src/Models/Endpoint.php
@@ -4,8 +4,6 @@ class Endpoint extends Model
 {
 	/**
 	 * Whether or not the kind is plural.
-	 * 
-	 * @var boolean
 	 */
 	protected bool $pluralKind = true;
 }

--- a/src/Models/Endpoint.php
+++ b/src/Models/Endpoint.php
@@ -7,5 +7,5 @@ class Endpoint extends Model
 	 * 
 	 * @var boolean
 	 */
-	protected $pluralKind = true;
+	protected bool $pluralKind = true;
 }

--- a/src/Models/HorizontalPodAutoscaler.php
+++ b/src/Models/HorizontalPodAutoscaler.php
@@ -7,5 +7,5 @@ class HorizontalPodAutoscaler extends \Maclof\Kubernetes\Models\Model
 	 *
 	 * @var string
 	 */
-	protected $apiVersion = 'autoscaling/v2beta1';
+	protected string $apiVersion = 'autoscaling/v2beta1';
 }

--- a/src/Models/HorizontalPodAutoscaler.php
+++ b/src/Models/HorizontalPodAutoscaler.php
@@ -4,8 +4,6 @@ class HorizontalPodAutoscaler extends \Maclof\Kubernetes\Models\Model
 {
 	/**
 	 * The api version.
-	 *
-	 * @var string
 	 */
 	protected string $apiVersion = 'autoscaling/v2beta1';
 }

--- a/src/Models/Ingress.php
+++ b/src/Models/Ingress.php
@@ -4,8 +4,6 @@ class Ingress extends Model
 {
 	/**
 	 * The api version.
-	 *
-	 * @var string
 	 */
 	protected string $apiVersion = 'networking.k8s.io/v1beta1';
 }

--- a/src/Models/Ingress.php
+++ b/src/Models/Ingress.php
@@ -7,5 +7,5 @@ class Ingress extends Model
 	 *
 	 * @var string
 	 */
-	protected $apiVersion = 'networking.k8s.io/v1beta1';
+	protected string $apiVersion = 'networking.k8s.io/v1beta1';
 }

--- a/src/Models/Issuer.php
+++ b/src/Models/Issuer.php
@@ -3,6 +3,6 @@
 class Issuer extends Model
 {
 
-    protected $apiVersion = 'certmanager.k8s.io/v1alpha1';
+    protected string $apiVersion = 'certmanager.k8s.io/v1alpha1';
 
 }

--- a/src/Models/Job.php
+++ b/src/Models/Job.php
@@ -4,8 +4,6 @@ class Job extends Model
 {
 	/**
 	 * The api version.
-	 *
-	 * @var string
 	 */
 	protected string $apiVersion = 'batch/v1';
 }

--- a/src/Models/Job.php
+++ b/src/Models/Job.php
@@ -7,5 +7,5 @@ class Job extends Model
 	 *
 	 * @var string
 	 */
-	protected $apiVersion = 'batch/v1';
+	protected string $apiVersion = 'batch/v1';
 }

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -12,40 +12,30 @@ abstract class Model implements Arrayable
 {
 	/**
 	 * The schema.
-	 *
-	 * @var array
 	 */
-	protected $schema = [];
+	protected array $schema = [];
 
 	/**
 	 * The api version.
-	 *
-	 * @var string
 	 */
-	protected $apiVersion = 'v1';
+	protected string $apiVersion = 'v1';
 
 	/**
 	 * Whether or not the kind is plural.
-	 *
-	 * @var boolean
 	 */
-	protected $pluralKind = false;
+	protected bool $pluralKind = false;
 
 	/**
 	 * The attributes.
-	 *
-	 * @var array
 	 */
-	protected $attributes = [];
+	protected array $attributes = [];
 
 	/**
 	 * The constructor.
 	 *
-	 * @param mixed  $attributes
-	 * @param string $attributeType
 	 * @throws \InvalidArgumentException
 	 */
-	public function __construct($attributes = [], $attributeType = 'array')
+	public function __construct(array $attributes = [], string $attributeType = 'array')
 	{
 		if ($attributeType == 'array') {
 			if (is_array($attributes)) {
@@ -80,21 +70,16 @@ abstract class Model implements Arrayable
 
 	/**
 	 * Get the model as an array.
-	 *
-	 * @return array
 	 */
-	public function toArray()
+	public function toArray(): array
 	{
 		return $this->attributes;
 	}
 
 	/**
 	 * Get some metadata.
-	 *
-	 * @param  string $key
-	 * @return string
 	 */
-	public function getMetadata($key)
+	public function getMetadata(string $key): ?string
 	{
 		return isset($this->attributes['metadata'][$key]) ? $this->attributes['metadata'][$key] : null;
 	}
@@ -102,11 +87,9 @@ abstract class Model implements Arrayable
 	/**
      * Get data ussing Json Path.
      *
-     * @param  string $expression
      * @throws JSONPathException
-     * @return mixed
      */
-    public function getJsonPath($expression)
+    public function getJsonPath(string $expression): JSONPath
     {
         $jsonPath = new JSONPath($this->attributes);
 
@@ -115,10 +98,8 @@ abstract class Model implements Arrayable
 
 	 /**
 	 * Get the schema.
-	 *
-	 * @return string
 	 */
-	public function getSchema()
+	public function getSchema(): string
 	{
 		if (!isset($this->schema['kind'])) {
 			$this->schema['kind'] = basename(str_replace('\\', '/', get_class($this)));
@@ -143,28 +124,22 @@ abstract class Model implements Arrayable
 
 	/**
 	 * Get the api version.
-	 *
-	 * @return string
 	 */
-	public function getApiVersion()
+	public function getApiVersion(): string
 	{
 		return $this->apiVersion;
 	}
 
 	/**
 	 * Set the api version.
-	 * 
-	 * @param string $apiVersion
 	 */
-	public function setApiVersion($apiVersion)
+	public function setApiVersion(string $apiVersion): void
 	{
 		$this->apiVersion = $apiVersion;
 	}
 
 	/**
 	 * Get the model as a string.
-	 *
-	 * @return string
 	 */
 	public function __toString()
 	{

--- a/src/Models/NamespaceModel.php
+++ b/src/Models/NamespaceModel.php
@@ -4,8 +4,6 @@ class NamespaceModel extends Model
 {
 	/**
 	 * The schema.
-	 *
-	 * @var array
 	 */
 	protected array $schema = ['kind' => 'Namespace'];
 }

--- a/src/Models/NamespaceModel.php
+++ b/src/Models/NamespaceModel.php
@@ -7,5 +7,5 @@ class NamespaceModel extends Model
 	 *
 	 * @var array
 	 */
-	protected $schema = ['kind' => 'Namespace'];
+	protected array $schema = ['kind' => 'Namespace'];
 }

--- a/src/Models/NetworkPolicy.php
+++ b/src/Models/NetworkPolicy.php
@@ -7,5 +7,5 @@ class NetworkPolicy extends Model
 	 *
 	 * @var string
 	 */
-	protected $apiVersion = 'networking.k8s.io/v1';
+	protected string $apiVersion = 'networking.k8s.io/v1';
 }

--- a/src/Models/NetworkPolicy.php
+++ b/src/Models/NetworkPolicy.php
@@ -4,8 +4,6 @@ class NetworkPolicy extends Model
 {
 	/**
 	 * The api version.
-	 *
-	 * @var string
 	 */
 	protected string $apiVersion = 'networking.k8s.io/v1';
 }

--- a/src/Models/ReplicaSet.php
+++ b/src/Models/ReplicaSet.php
@@ -4,8 +4,6 @@ class ReplicaSet extends Model
 {
 	/**
 	 * The api version.
-	 *
-	 * @var string
 	 */
 	protected string $apiVersion = 'extensions/v1beta1';
 }

--- a/src/Models/ReplicaSet.php
+++ b/src/Models/ReplicaSet.php
@@ -7,5 +7,5 @@ class ReplicaSet extends Model
 	 *
 	 * @var string
 	 */
-	protected $apiVersion = 'extensions/v1beta1';
+	protected string $apiVersion = 'extensions/v1beta1';
 }

--- a/src/Repositories/CertificateRepository.php
+++ b/src/Repositories/CertificateRepository.php
@@ -7,9 +7,9 @@ class CertificateRepository extends Repository
 {
     use PatchMergeTrait;
 
-    protected $uri = 'certificates';
+    protected string $uri = 'certificates';
 
-    protected function createCollection($response)
+    protected function createCollection($response): CertificateCollection
     {
         return new CertificateCollection($response['items']);
     }

--- a/src/Repositories/ConfigMapRepository.php
+++ b/src/Repositories/ConfigMapRepository.php
@@ -4,9 +4,9 @@ use Maclof\Kubernetes\Collections\ConfigMapCollection;
 
 class ConfigMapRepository extends Repository
 {
-	protected $uri = 'configmaps';
+	protected string $uri = 'configmaps';
 
-	protected function createCollection($response)
+	protected function createCollection($response): ConfigMapCollection
 	{
 		return new ConfigMapCollection($response['items']);
 	}

--- a/src/Repositories/CronJobRepository.php
+++ b/src/Repositories/CronJobRepository.php
@@ -4,9 +4,9 @@ use Maclof\Kubernetes\Collections\CronJobCollection;
 
 class CronJobRepository extends Repository
 {
-	protected $uri = 'cronjobs';
+	protected string $uri = 'cronjobs';
 
-	protected function createCollection($response)
+	protected function createCollection($response): CronJobCollection
 	{
 		return new CronJobCollection($response['items']);
 	}

--- a/src/Repositories/DaemonSetRepository.php
+++ b/src/Repositories/DaemonSetRepository.php
@@ -4,9 +4,9 @@ use Maclof\Kubernetes\Collections\DaemonSetCollection;
 
 class DaemonSetRepository extends Repository
 {
-	protected $uri = 'daemonsets';
+	protected string $uri = 'daemonsets';
 
-	protected function createCollection($response)
+	protected function createCollection($response): DaemonSetCollection
 	{
 		return new DaemonSetCollection($response['items']);
 	}

--- a/src/Repositories/DeploymentRepository.php
+++ b/src/Repositories/DeploymentRepository.php
@@ -4,9 +4,9 @@ use Maclof\Kubernetes\Collections\DeploymentCollection;
 
 class DeploymentRepository extends Repository
 {
-	protected $uri = 'deployments';
+	protected string $uri = 'deployments';
 
-	protected function createCollection($response)
+	protected function createCollection($response): DeploymentCollection
 	{
 		return new DeploymentCollection($response['items']);
 	}

--- a/src/Repositories/EndpointRepository.php
+++ b/src/Repositories/EndpointRepository.php
@@ -4,9 +4,9 @@ use Maclof\Kubernetes\Collections\EndpointCollection;
 
 class EndpointRepository extends Repository
 {
-	protected $uri = 'endpoints';
+	protected string $uri = 'endpoints';
 
-	protected function createCollection($response)
+	protected function createCollection($response): EndpointCollection
 	{
 		return new EndpointCollection($response['items']);
 	}

--- a/src/Repositories/EventRepository.php
+++ b/src/Repositories/EventRepository.php
@@ -4,9 +4,9 @@ use Maclof\Kubernetes\Collections\EventCollection;
 
 class EventRepository extends Repository
 {
-	protected $uri = 'events';
+	protected string $uri = 'events';
 
-	protected function createCollection($response)
+	protected function createCollection($response): EventCollection
 	{
 		return new EventCollection($response['items']);
 	}

--- a/src/Repositories/HorizontalPodAutoscalerRepository.php
+++ b/src/Repositories/HorizontalPodAutoscalerRepository.php
@@ -4,9 +4,9 @@ use Maclof\Kubernetes\Collections\HorizontalPodAutoscalerCollection;
 
 class HorizontalPodAutoscalerRepository extends Repository
 {
-	protected $uri = 'horizontalpodautoscalers';
+	protected string $uri = 'horizontalpodautoscalers';
 
-	protected function createCollection($response)
+	protected function createCollection($response): HorizontalPodAutoscalerCollection
 	{
 		return new HorizontalPodAutoscalerCollection($response['items']);
 	}

--- a/src/Repositories/IngressRepository.php
+++ b/src/Repositories/IngressRepository.php
@@ -4,9 +4,9 @@ use Maclof\Kubernetes\Collections\IngressCollection;
 
 class IngressRepository extends Repository
 {
-	protected $uri = 'ingresses';
+	protected string $uri = 'ingresses';
 
-	protected function createCollection($response)
+	protected function createCollection($response): IngressCollection
 	{
 		return new IngressCollection($response['items']);
 	}

--- a/src/Repositories/IssuerRepository.php
+++ b/src/Repositories/IssuerRepository.php
@@ -7,9 +7,9 @@ class IssuerRepository extends Repository
 {
     use PatchMergeTrait;
 
-    protected $uri = 'issuers';
+    protected string $uri = 'issuers';
 
-    protected function createCollection($response)
+    protected function createCollection($response): IssuerCollection
     {
         return new IssuerCollection($response['items']);
     }

--- a/src/Repositories/JobRepository.php
+++ b/src/Repositories/JobRepository.php
@@ -4,9 +4,9 @@ use Maclof\Kubernetes\Collections\JobCollection;
 
 class JobRepository extends Repository
 {
-	protected $uri = 'jobs';
+	protected string $uri = 'jobs';
 
-	protected function createCollection($response)
+	protected function createCollection($response): JobCollection
 	{
 		return new JobCollection($response['items']);
 	}

--- a/src/Repositories/NamespaceRepository.php
+++ b/src/Repositories/NamespaceRepository.php
@@ -4,10 +4,10 @@ use Maclof\Kubernetes\Collections\NamespaceCollection;
 
 class NamespaceRepository extends Repository
 {
-	protected $uri = 'namespaces';
-	protected $namespace = false;
+	protected string $uri = 'namespaces';
+	protected bool $namespace = false;
 
-	protected function createCollection($response)
+	protected function createCollection($response): NamespaceCollection
 	{
 		return new NamespaceCollection($response['items']);
 	}

--- a/src/Repositories/NetworkPolicyRepository.php
+++ b/src/Repositories/NetworkPolicyRepository.php
@@ -4,9 +4,9 @@ use Maclof\Kubernetes\Collections\NetworkPolicyCollection;
 
 class NetworkPolicyRepository extends Repository
 {
-	protected $uri = 'networkpolicies';
+	protected string $uri = 'networkpolicies';
 
-	protected function createCollection($response)
+	protected function createCollection($response): NetworkPolicyCollection
 	{
 		return new NetworkPolicyCollection($response['items']);
 	}

--- a/src/Repositories/NodeRepository.php
+++ b/src/Repositories/NodeRepository.php
@@ -1,18 +1,19 @@
 <?php namespace Maclof\Kubernetes\Repositories;
 
 use Maclof\Kubernetes\Collections\NodeCollection;
+use Maclof\Kubernetes\Models\Node;
 
 class NodeRepository extends Repository
 {
-	protected $uri = 'nodes';
-	protected $namespace = false;
+	protected string $uri = 'nodes';
+	protected bool $namespace = false;
 
-	protected function createCollection($response)
+	protected function createCollection($response): NodeCollection
 	{
 		return new NodeCollection($response['items']);
 	}
 
-	public function proxy($node, $method, $proxy_uri, array $queryParams = [])
+	public function proxy(Node $node, string $method, string $proxy_uri, array $queryParams = [])
 	{
 		$response = $this->client->sendRequest($method, '/' . $this->uri . '/' . $node->getMetadata('name') . '/proxy/' . $proxy_uri, $queryParams, [], $this->namespace);
 		return $response;

--- a/src/Repositories/PersistentVolumeClaimRepository.php
+++ b/src/Repositories/PersistentVolumeClaimRepository.php
@@ -4,9 +4,9 @@ use Maclof\Kubernetes\Collections\PersistentVolumeClaimCollection;
 
 class PersistentVolumeClaimRepository extends Repository
 {
-	protected $uri = 'persistentvolumeclaims';
+	protected string $uri = 'persistentvolumeclaims';
 
-	protected function createCollection($response)
+	protected function createCollection($response): PersistentVolumeClaimCollection
 	{
 		return new PersistentVolumeClaimCollection($response['items']);
 	}

--- a/src/Repositories/PersistentVolumeRepository.php
+++ b/src/Repositories/PersistentVolumeRepository.php
@@ -18,12 +18,8 @@ class PersistentVolumeRepository extends Repository
 	/**
 	 * Send a request.
 	 *
-	 * @param  string  $method
-	 * @param  string  $uri
-	 * @param  array   $query
-	 * @param  mixed   $body
-	 * @param  boolean $namespace
-	 * @return array
+	 * @param mixed $body
+	 * @return mixed
 	 */
 	protected function sendRequest(string $method, string $uri, array $query = [], $body = [], bool $namespace = false, array $requestOptions = [])
 	{

--- a/src/Repositories/PersistentVolumeRepository.php
+++ b/src/Repositories/PersistentVolumeRepository.php
@@ -5,12 +5,12 @@ use Maclof\Kubernetes\Collections\PersistentVolumeCollection;
 
 class PersistentVolumeRepository extends Repository
 {
-	protected $uri = 'persistentvolumes';
+	protected string $uri = 'persistentvolumes';
 
 	/**
 	 * @see \Maclof\Kubernetes\Repositories\Repository::createCollection()
 	 */
-	protected function createCollection($response)
+	protected function createCollection($response): PersistentVolumeCollection
 	{
 		return new PersistentVolumeCollection($response['items']);
 	}
@@ -25,7 +25,7 @@ class PersistentVolumeRepository extends Repository
 	 * @param  boolean $namespace
 	 * @return array
 	 */
-	protected function sendRequest($method, $uri, $query = [], $body = [], $namespace = false)
+	protected function sendRequest(string $method, string $uri, array $query = [], $body = [], bool $namespace = false, array $requestOptions = [])
 	{
 		$namespace = false;
 		$apiVersion = $this->getApiVersion();

--- a/src/Repositories/PodRepository.php
+++ b/src/Repositories/PodRepository.php
@@ -14,10 +14,6 @@ class PodRepository extends Repository
 
 	/**
 	 * Get the logs for a pod.
-	 *
-	 * @param  \Maclof\Kubernetes\Models\Pod $pod
-	 * @param  array $queryParams
-	 * @return string
 	 */
 	public function logs(Pod $pod, array $queryParams = []): string
 	{
@@ -28,8 +24,6 @@ class PodRepository extends Repository
 	/**
 	 * Execute a command on a pod.
 	 *
-	 * @param  \Maclof\Kubernetes\Models\Pod $pod
-	 * @param  array $queryParams
 	 * @return mixed
 	 */
 	public function exec(Pod $pod, array $queryParams = [])

--- a/src/Repositories/PodRepository.php
+++ b/src/Repositories/PodRepository.php
@@ -26,6 +26,7 @@ class PodRepository extends Repository
 	 *
 	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function exec(Pod $pod, array $queryParams = [])
 	{
 		$response = $this->client->sendRequest('POST', '/' . $this->uri . '/' . $pod->getMetadata('name') . '/exec', $queryParams);

--- a/src/Repositories/PodRepository.php
+++ b/src/Repositories/PodRepository.php
@@ -5,9 +5,9 @@ use Maclof\Kubernetes\Collections\PodCollection;
 
 class PodRepository extends Repository
 {
-	protected $uri = 'pods';
+	protected string $uri = 'pods';
 
-	protected function createCollection($response)
+	protected function createCollection($response): PodCollection
 	{
 		return new PodCollection($response['items']);
 	}
@@ -19,7 +19,7 @@ class PodRepository extends Repository
 	 * @param  array $queryParams
 	 * @return string
 	 */
-	public function logs(Pod $pod, array $queryParams = [])
+	public function logs(Pod $pod, array $queryParams = []): string
 	{
 		$response = $this->client->sendRequest('GET', '/' . $this->uri . '/' . $pod->getMetadata('name') . '/log', $queryParams);
 		return $response;

--- a/src/Repositories/QuotaRepository.php
+++ b/src/Repositories/QuotaRepository.php
@@ -4,10 +4,10 @@ use Maclof\Kubernetes\Collections\QuotaCollection;
 
 class QuotaRepository extends Repository
 {
-	protected $uri = 'resourcequotas';
-	protected $namespace = false;
+	protected string $uri = 'resourcequotas';
+	protected bool $namespace = false;
 
-	protected function createCollection($response)
+	protected function createCollection($response): QuotaCollection
 	{
 		return new QuotaCollection($response['items']);
 	}

--- a/src/Repositories/ReplicaSetRepository.php
+++ b/src/Repositories/ReplicaSetRepository.php
@@ -4,9 +4,9 @@ use Maclof\Kubernetes\Collections\ReplicaSetCollection;
 
 class ReplicaSetRepository extends Repository
 {
-	protected $uri = 'replicasets';
+	protected string $uri = 'replicasets';
 
-	protected function createCollection($response)
+	protected function createCollection($response): ReplicaSetCollection
 	{
 		return new ReplicaSetCollection($response['items']);
 	}

--- a/src/Repositories/ReplicationControllerRepository.php
+++ b/src/Repositories/ReplicationControllerRepository.php
@@ -4,9 +4,9 @@ use Maclof\Kubernetes\Collections\ReplicationControllerCollection;
 
 class ReplicationControllerRepository extends Repository
 {
-	protected $uri = 'replicationcontrollers';
+	protected string $uri = 'replicationcontrollers';
 
-	protected function createCollection($response)
+	protected function createCollection($response): ReplicationControllerCollection
 	{
 		return new ReplicationControllerCollection($response['items']);
 	}

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -12,8 +12,6 @@ abstract class Repository
 {
 	/**
 	 * The client.
-	 *
-	 * @var \Maclof\Kubernetes\Client
 	 */
 	protected Client $client;
 
@@ -24,57 +22,41 @@ abstract class Repository
 
 	/**
 	 * Include the namespace in the requests.
-	 *
-	 * @var boolean
 	 */
 	protected bool $namespace = true;
 
 	/**
 	 * The api version to use for requests.
-	 *
-	 * @var null
 	 */
 	protected ?string $apiVersion = null;
 
 	/**
 	 * The label selector.
-	 *
-	 * @var array
 	 */
 	protected array $labelSelector = [];
 
 	/**
 	 * The label selector options that should not match.
-	 *
-	 * @var array
 	 */
 	protected array $inequalityLabelSelector = [];
 
 	/**
 	 * The field selector.
-	 *
-	 * @var array
 	 */
 	protected array $fieldSelector = [];
 
 	/**
 	 * The field selector options that should not match.
-	 *
-	 * @var array
 	 */
 	protected array $inequalityFieldSelector = [];
 
 	/**
 	 * The default class namespace of the repositories
-	 * 
-	 * @var string
 	 */
 	protected string $modelClassNamespace = 'Maclof\Kubernetes\Models\\';
 
 	/**
 	 * The constructor.
-	 *
-	 * @param \Maclof\Kubernetes\Client $client
 	 */
 	public function __construct(Client $client)
 	{
@@ -84,13 +66,8 @@ abstract class Repository
 	/**
 	 * Send a request.
 	 *
-	 * @param  string  $method
-	 * @param  string  $uri
-	 * @param  array   $query
-	 * @param  mixed   $body
-	 * @param  boolean $namespace
-	 * @param  array   $requestOptions
-	 * @return array
+	 * @param mixed $body
+	 * @return mixed
 	 */
 	protected function sendRequest(string $method, string $uri, array $query = [], $body = [], bool $namespace = true, array $requestOptions = [])
 	{
@@ -104,8 +81,6 @@ abstract class Repository
 
 	/**
 	 * Get the api version from the model.
-	 *
-	 * @return string|null
 	 */
 	protected function getApiVersion(): ?string
 	{
@@ -127,9 +102,6 @@ abstract class Repository
 
 	/**
 	 * Create a new model.
-	 *
-	 * @param  \Maclof\Kubernetes\Models\Model $model
-	 * @return array
 	 */
 	public function create(Model $model): array
 	{
@@ -138,9 +110,6 @@ abstract class Repository
 
 	/**
 	 * Update a model.
-	 *
-	 * @param  \Maclof\Kubernetes\Models\Model $model
-	 * @return array
 	 */
 	public function update(Model $model): array
 	{
@@ -149,9 +118,6 @@ abstract class Repository
 
 	/**
 	 * Patch a model.
-	 *
-	 * @param \Maclof\Kubernetes\Models\Model $model
-	 * @return array
 	 */
 	public function patch(Model $model): array
 	{
@@ -160,10 +126,6 @@ abstract class Repository
 
 	/**
 	 * Apply a json patch to a model.
-	 *
-	 * @param \Maclof\Kubernetes\Models\Model $model
-	 * @param array $model
-	 * @return array
 	 */
 	public function applyJsonPatch(Model $model, array $patch): array
 	{
@@ -178,9 +140,6 @@ abstract class Repository
      * Apply a model.
      *
      * Creates a new api object if not exists, or patch.
-     *
-     * @param \Maclof\Kubernetes\Models\Model $model
-     * @return array
      */
 	public function apply(Model $model): array
     {
@@ -195,10 +154,6 @@ abstract class Repository
 
 	/**
 	 * Delete a model.
-	 *
-	 * @param  \Maclof\Kubernetes\Models\Model         $model
-	 * @param  \Maclof\Kubernetes\Models\DeleteOptions $options
-	 * @return array
 	 */
 	public function delete(Model $model, DeleteOptions $options = null): array
 	{
@@ -207,10 +162,6 @@ abstract class Repository
 
 	/**
 	 * Delete a model by name.
-	 *
-	 * @param  string                                  $name
-	 * @param  \Maclof\Kubernetes\Models\DeleteOptions $options
-	 * @return array
 	 */
 	public function deleteByName(string $name, DeleteOptions $options = null): array
 	{
@@ -221,10 +172,6 @@ abstract class Repository
 
 	/**
 	 * Set the label selector including inequality search terms.
-	 *
-	 * @param  array $labelSelector
-	 * @param  array $inequalityLabelSelector
-	 * @return \Maclof\Kubernetes\Repositories\Repository
 	 */
 	public function setLabelSelector(array $labelSelector, array $inequalityLabelSelector=[]): Repository
 	{
@@ -235,8 +182,6 @@ abstract class Repository
 
 	/**
 	 * Get the label selector query.
-	 *
-	 * @return string
 	 */
 	protected function getLabelSelectorQuery(): string
 	{
@@ -256,10 +201,6 @@ abstract class Repository
 
 	/**
 	 * Set the field selector including inequality search terms.
-	 *
-	 * @param  array $fieldSelector
-	 * @param  array $inequalityFieldSelector
-	 * @return \Maclof\Kubernetes\Repositories\Repository
 	 */
 	public function setFieldSelector(array $fieldSelector, array $inequalityFieldSelector=[]): Repository
 	{
@@ -270,8 +211,6 @@ abstract class Repository
 
 	/**
 	 * Get the field selector query.
-	 *
-	 * @return string
 	 */
 	protected function getFieldSelectorQuery(): string
 	{
@@ -292,8 +231,6 @@ abstract class Repository
 
 	/**
 	 * Reset the parameters.
-	 *
-	 * @return void
 	 */
 	protected function resetParameters(): void
 	{
@@ -303,9 +240,6 @@ abstract class Repository
 
 	/**
 	 * Get a collection of items.
-	 *
-	 * @param  array $query
-	 * @return mixed
 	 */
 	public function find(array $query = []): Collection
 	{
@@ -325,8 +259,6 @@ abstract class Repository
 
 	/**
 	 * Find the first item.
-	 *
-	 * @return \Maclof\Kubernetes\Models\Model|null
 	 */
 	public function first(): ?Model
 	{
@@ -335,11 +267,6 @@ abstract class Repository
 
 	/**
 	 * Watch a model for changes.
-	 *
-	 * @param  \Maclof\Kubernetes\Models\Model $model
-	 * @param  \Closure $closure
-	 * @param  array $query
-	 * @return void
 	 */
 	public function watch(Model $model, Closure $closure, array $query = []): void
 	{
@@ -371,9 +298,6 @@ abstract class Repository
 
 	/**
 	 * Check if an item exists by name.
-	 *
-	 * @param  string $name
-	 * @return boolean
 	 */
 	public function exists(string $name): bool
 	{
@@ -383,9 +307,6 @@ abstract class Repository
 
 	/**
 	 * Create a collection of models from the response.
-	 *
-	 * @param  array $response
-	 * @return \Maclof\Kubernetes\Collections\Collection
 	 */
 	abstract protected function createCollection(array $response): Collection;
 }

--- a/src/Repositories/SecretRepository.php
+++ b/src/Repositories/SecretRepository.php
@@ -4,9 +4,9 @@ use Maclof\Kubernetes\Collections\SecretCollection;
 
 class SecretRepository extends Repository
 {
-	protected $uri = 'secrets';
+	protected string $uri = 'secrets';
 
-	protected function createCollection($response)
+	protected function createCollection($response): SecretCollection
 	{
 		return new SecretCollection($response['items']);
 	}

--- a/src/Repositories/ServiceRepository.php
+++ b/src/Repositories/ServiceRepository.php
@@ -4,9 +4,9 @@ use Maclof\Kubernetes\Collections\ServiceCollection;
 
 class ServiceRepository extends Repository
 {
-	protected $uri = 'services';
+	protected string $uri = 'services';
 
-	protected function createCollection($response)
+	protected function createCollection($response): ServiceCollection
 	{
 		return new ServiceCollection($response['items']);
 	}

--- a/src/Repositories/Strategy/PatchMergeTrait.php
+++ b/src/Repositories/Strategy/PatchMergeTrait.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\Model;
 
 trait PatchMergeTrait {
 
-    public function patch(Model $model)
+    public function patch(Model $model): array
     {
         $this->client->setPatchType("merge");
 

--- a/src/Repositories/Utils/JSONStreamingListener.php
+++ b/src/Repositories/Utils/JSONStreamingListener.php
@@ -6,50 +6,36 @@ class JSONStreamingListener
 {
 	/**
 	 * The closure to call.
-	 * 
-	 * @var \Closure
 	 */
 	protected Closure $closure;
 
 	/**
 	 * The current depth within the JSON stream.
-	 *
-	 * @var int
 	 */
 	protected int $depth = 0;
 
 	/**
 	 * The current JSON object stack.
-	 *
-	 * @var array
 	 */
 	protected array $stack = [];
 
 	/**
 	 * The current key for each depth.
-	 *
-	 * @var array
 	 */
 	protected array $keyByDepth = [];
 
 	/**
 	 * The current position within the JSON stream.
-	 *
-	 * @var array
 	 */
 	protected array $breadcrumbs = [];
 
 	/**
 	 * The target containing the JSON objects.
-	 *
-	 * @var array
 	 */
 	protected array $target = [];
 
 	/**
 	 * The constructor.
-	 * 
-	 * @param \Closure $closure
 	 */
 	public function __construct(Closure $closure)
 	{
@@ -58,9 +44,6 @@ class JSONStreamingListener
 
 	/**
 	 * Set the target from the given key
-	 *
-	 * @param string $key
-	 * @return void
 	 */
 	public function setTargetFromKey(string $key) : self
 	{
@@ -72,8 +55,6 @@ class JSONStreamingListener
 
 	/**
 	 * Listen to the start of the document.
-	 *
-	 * @return void
 	 */
 	public function startDocument() : void
 	{
@@ -82,8 +63,6 @@ class JSONStreamingListener
 
 	/**
 	 * Listen to the end of the document.
-	 *
-	 * @return void
 	 */
 	public function endDocument() : void
 	{
@@ -95,8 +74,6 @@ class JSONStreamingListener
 
 	/**
 	 * Listen to the start of the object.
-	 *
-	 * @return void
 	 */
 	public function startObject() : void
 	{
@@ -111,8 +88,6 @@ class JSONStreamingListener
 
 	/**
 	 * Determine whether the current object should be extracted
-	 *
-	 * @return bool
 	 */
 	protected function shouldBeExtracted() : bool
 	{
@@ -128,8 +103,6 @@ class JSONStreamingListener
 
 	/**
 	 * Listen to the end of the object.
-	 *
-	 * @return void
 	 */
 	public function endObject() : void
 	{
@@ -156,8 +129,6 @@ class JSONStreamingListener
 
 	/**
 	 * Determine whether the current object should be skipped
-	 *
-	 * @return bool
 	 */
 	protected function shouldBeSkipped() : bool
 	{
@@ -166,9 +137,6 @@ class JSONStreamingListener
 
 	/**
 	 * Process the given extracted object.
-	 *
-	 * @param array $extractedObject
-	 * @return void
 	 */
 	protected function processExtractedObject(array $extractedObject): void
 	{
@@ -183,8 +151,6 @@ class JSONStreamingListener
 
 	/**
 	 * Listen to the start of the array.
-	 *
-	 * @return void
 	 */
 	public function startArray() : void
 	{
@@ -208,8 +174,6 @@ class JSONStreamingListener
 
 	/**
 	 * Determine whether the current element is the target
-	 *
-	 * @return bool
 	 */
 	protected function isTarget() : bool
 	{
@@ -223,8 +187,6 @@ class JSONStreamingListener
 
 	/**
 	 * Listen to the end of the array.
-	 *
-	 * @return void
 	 */
 	public function endArray() : void
 	{
@@ -251,9 +213,6 @@ class JSONStreamingListener
 
 	/**
 	 * Listen to the key.
-	 *
-	 * @param string $key
-	 * @return void
 	 */
 	public function key(string $key) : void
 	{
@@ -270,7 +229,6 @@ class JSONStreamingListener
 	 * Listen to the value.
 	 *
 	 * @param mixed $value
-	 * @return void
 	 */
 	public function value($value) : void
 	{
@@ -293,9 +251,6 @@ class JSONStreamingListener
 
 	/**
 	 * Listen to the whitespace.
-	 *
-	 * @param string $whitespace
-	 * @return void
 	 */
 	public function whitespace(string $whitespace) : void
 	{

--- a/src/Repositories/Utils/JSONStreamingListener.php
+++ b/src/Repositories/Utils/JSONStreamingListener.php
@@ -9,42 +9,42 @@ class JSONStreamingListener
 	 * 
 	 * @var \Closure
 	 */
-	protected $closure;
+	protected Closure $closure;
 
 	/**
 	 * The current depth within the JSON stream.
 	 *
 	 * @var int
 	 */
-	protected $depth = 0;
+	protected int $depth = 0;
 
 	/**
 	 * The current JSON object stack.
 	 *
 	 * @var array
 	 */
-	protected $stack = [];
+	protected array $stack = [];
 
 	/**
 	 * The current key for each depth.
 	 *
 	 * @var array
 	 */
-	protected $keyByDepth = [];
+	protected array $keyByDepth = [];
 
 	/**
 	 * The current position within the JSON stream.
 	 *
 	 * @var array
 	 */
-	protected $breadcrumbs = [];
+	protected array $breadcrumbs = [];
 
 	/**
 	 * The target containing the JSON objects.
 	 *
 	 * @var array
 	 */
-	protected $target = [];
+	protected array $target = [];
 
 	/**
 	 * The constructor.
@@ -170,7 +170,7 @@ class JSONStreamingListener
 	 * @param array $extractedObject
 	 * @return void
 	 */
-	protected function processExtractedObject(array $extractedObject)
+	protected function processExtractedObject(array $extractedObject): void
 	{
 		$type = isset($extractedObject['type']) ? $extractedObject['type'] : null;
 		$object = isset($extractedObject['object']) ? $extractedObject['object'] : null;

--- a/src/Repositories/Utils/JSONStreamingParser.php
+++ b/src/Repositories/Utils/JSONStreamingParser.php
@@ -30,9 +30,6 @@ class JSONStreamingParser
 	const UTF16_BOM = 2;
 	const UTF32_BOM = 3;
 
-	/**
-	 * @var int
-	 */
 	private int $state;
 
 	/**
@@ -40,26 +37,14 @@ class JSONStreamingParser
 	 */
 	private array $stack = [];
 
-	/**
-	 * @var \GuzzleHttp\Psr7\Stream
-	 */
 	private Stream $stream;
 
 	private JSONStreamingListener $listener;
 
-	/**
-	 * @var bool
-	 */
 	private bool $emitWhitespace;
 
-	/**
-	 * @var string
-	 */
 	private string $buffer = '';
 
-	/**
-	 * @var int
-	 */
 	private int $bufferSize;
 
 	/**
@@ -67,49 +52,22 @@ class JSONStreamingParser
 	 */
 	private array $unicodeBuffer = [];
 
-	/**
-	 * @var int
-	 */
 	private int $unicodeHighSurrogate = -1;
 
-	/**
-	 * @var string
-	 */
 	private string $unicodeEscapeBuffer = '';
 
-	/**
-	 * @var string
-	 */
 	private string $lineEnding;
 
-	/**
-	 * @var int
-	 */
 	private int $lineNumber;
 
-	/**
-	 * @var int
-	 */
 	private int $charNumber;
 
-	/**
-	 * @var bool
-	 */
 	private bool $stopParsing = false;
 
-	/**
-	 * @var int
-	 */
 	private int $utfBom = 0;
 
 	/**
 	 * The constructor.
-	 *
-	 * @param \GuzzleHttp\Psr7\Stream $stream
-	 * @param \Maclof\Kubernetes\Repositories\Utils\JSONStreamingListener $listener
-	 * @param string $lineEnding
-	 * @param bool|boolean $emitWhitespace
-	 * @param int|integer $bufferSize
 	 */
 	public function __construct(
 		Stream $stream,
@@ -128,8 +86,6 @@ class JSONStreamingParser
 
 	/**
 	 * Parse the stream.
-	 *
-	 * @return void
 	 */
 	public function parse(): void
 	{

--- a/src/Repositories/Utils/JSONStreamingParser.php
+++ b/src/Repositories/Utils/JSONStreamingParser.php
@@ -33,76 +33,78 @@ class JSONStreamingParser
 	/**
 	 * @var int
 	 */
-	private $state;
+	private int $state;
 
 	/**
 	 * @var int[]
 	 */
-	private $stack = [];
+	private array $stack = [];
 
 	/**
 	 * @var \GuzzleHttp\Psr7\Stream
 	 */
-	private $stream;
+	private Stream $stream;
+
+	private JSONStreamingListener $listener;
 
 	/**
 	 * @var bool
 	 */
-	private $emitWhitespace;
+	private bool $emitWhitespace;
 
 	/**
 	 * @var string
 	 */
-	private $buffer = '';
+	private string $buffer = '';
 
 	/**
 	 * @var int
 	 */
-	private $bufferSize;
+	private int $bufferSize;
 
 	/**
 	 * @var string[]
 	 */
-	private $unicodeBuffer = [];
+	private array $unicodeBuffer = [];
 
 	/**
 	 * @var int
 	 */
-	private $unicodeHighSurrogate = -1;
+	private int $unicodeHighSurrogate = -1;
 
 	/**
 	 * @var string
 	 */
-	private $unicodeEscapeBuffer = '';
+	private string $unicodeEscapeBuffer = '';
 
 	/**
 	 * @var string
 	 */
-	private $lineEnding;
+	private string $lineEnding;
 
 	/**
 	 * @var int
 	 */
-	private $lineNumber;
+	private int $lineNumber;
 
 	/**
 	 * @var int
 	 */
-	private $charNumber;
+	private int $charNumber;
 
 	/**
 	 * @var bool
 	 */
-	private $stopParsing = false;
+	private bool $stopParsing = false;
 
 	/**
 	 * @var int
 	 */
-	private $utfBom = 0;
+	private int $utfBom = 0;
 
 	/**
 	 * The constructor.
-	 * 
+	 *
 	 * @param \GuzzleHttp\Psr7\Stream $stream
 	 * @param \Maclof\Kubernetes\Repositories\Utils\JSONStreamingListener $listener
 	 * @param string $lineEnding
@@ -126,10 +128,10 @@ class JSONStreamingParser
 
 	/**
 	 * Parse the stream.
-	 * 
+	 *
 	 * @return void
 	 */
-	public function parse()
+	public function parse(): void
 	{
 		$this->lineNumber = 1;
 		$this->charNumber = 1;
@@ -151,12 +153,12 @@ class JSONStreamingParser
 		}
 	}
 
-	public function stop()
+	public function stop(): void
 	{
 		$this->stopParsing = true;
 	}
 
-	private function consumeChar(string $char)
+	private function consumeChar(string $char): void
 	{
 		// see https://en.wikipedia.org/wiki/Byte_order_mark
 		if ($this->charNumber < 5
@@ -380,7 +382,7 @@ class JSONStreamingParser
 	/**
 	 * @throws ParsingException
 	 */
-	private function startValue(string $c)
+	private function startValue(string $c): void
 	{
 		if ('[' === $c) {
 			$this->startArray();
@@ -404,14 +406,14 @@ class JSONStreamingParser
 		}
 	}
 
-	private function startArray()
+	private function startArray(): void
 	{
 		$this->listener->startArray();
 		$this->state = self::STATE_IN_ARRAY;
 		$this->stack[] = self::STACK_ARRAY;
 	}
 
-	private function endArray()
+	private function endArray(): void
 	{
 		$popped = array_pop($this->stack);
 		if (self::STACK_ARRAY !== $popped) {
@@ -425,14 +427,14 @@ class JSONStreamingParser
 		}
 	}
 
-	private function startObject()
+	private function startObject(): void
 	{
 		$this->listener->startObject();
 		$this->state = self::STATE_IN_OBJECT;
 		$this->stack[] = self::STACK_OBJECT;
 	}
 
-	private function endObject()
+	private function endObject(): void
 	{
 		$popped = array_pop($this->stack);
 		if (self::STACK_OBJECT !== $popped) {
@@ -446,19 +448,19 @@ class JSONStreamingParser
 		}
 	}
 
-	private function startString()
+	private function startString(): void
 	{
 		$this->stack[] = self::STACK_STRING;
 		$this->state = self::STATE_IN_STRING;
 	}
 
-	private function startKey()
+	private function startKey(): void
 	{
 		$this->stack[] = self::STACK_KEY;
 		$this->state = self::STATE_IN_STRING;
 	}
 
-	private function endString()
+	private function endString(): void
 	{
 		$popped = array_pop($this->stack);
 		if (self::STACK_KEY === $popped) {
@@ -476,7 +478,7 @@ class JSONStreamingParser
 	/**
 	 * @throws ParsingException
 	 */
-	private function processEscapeCharacter(string $c)
+	private function processEscapeCharacter(string $c): void
 	{
 		if ('"' === $c) {
 			$this->buffer .= '"';
@@ -508,7 +510,7 @@ class JSONStreamingParser
 	/**
 	 * @throws ParsingException
 	 */
-	private function processUnicodeCharacter(string $char)
+	private function processUnicodeCharacter(string $char): void
 	{
 		if (!JSONStreamingParserHelper::isHexCharacter($char)) {
 			$this->throwParseError(
@@ -541,7 +543,7 @@ class JSONStreamingParser
 		}
 	}
 
-	private function endUnicodeSurrogateInterstitial()
+	private function endUnicodeSurrogateInterstitial(): void
 	{
 		$unicodeEscape = $this->unicodeEscapeBuffer;
 		if ('\\u' !== $unicodeEscape) {
@@ -551,7 +553,7 @@ class JSONStreamingParser
 		$this->state = self::STATE_UNICODE;
 	}
 
-	private function endUnicodeCharacter(int $codepoint)
+	private function endUnicodeCharacter(int $codepoint): void
 	{
 		$this->buffer .= JSONStreamingParserHelper::convertCodepointToCharacter($codepoint);
 		$this->unicodeBuffer = [];
@@ -559,35 +561,35 @@ class JSONStreamingParser
 		$this->state = self::STATE_IN_STRING;
 	}
 
-	private function startNumber(string $c)
+	private function startNumber(string $c): void
 	{
 		$this->state = self::STATE_IN_NUMBER;
 		$this->buffer .= $c;
 	}
 
-	private function endNumber()
+	private function endNumber(): void
 	{
 		$this->listener->value(JSONStreamingParserHelper::convertToNumber($this->buffer));
 		$this->buffer = '';
 		$this->state = self::STATE_AFTER_VALUE;
 	}
 
-	private function endTrue()
+	private function endTrue(): void
 	{
 		$this->endSpecialValue(true, 'true');
 	}
 
-	private function endFalse()
+	private function endFalse(): void
 	{
 		$this->endSpecialValue(false, 'false');
 	}
 
-	private function endNull()
+	private function endNull(): void
 	{
 		$this->endSpecialValue(null, 'null');
 	}
 
-	private function endSpecialValue($value, string $stringValue)
+	private function endSpecialValue($value, string $stringValue): void
 	{
 		if ($this->buffer === $stringValue) {
 			$this->listener->value($value);
@@ -598,7 +600,7 @@ class JSONStreamingParser
 		$this->state = self::STATE_AFTER_VALUE;
 	}
 
-	private function endDocument()
+	private function endDocument(): void
 	{
 		$this->listener->endDocument();
 		$this->state = self::STATE_END_DOCUMENT;
@@ -607,7 +609,7 @@ class JSONStreamingParser
 	/**
 	 * @throws ParsingException
 	 */
-	private function throwParseError(string $message)
+	private function throwParseError(string $message): void
 	{
 		throw new ParsingException($this->lineNumber, $this->charNumber, $message);
 	}

--- a/src/RepositoryRegistry.php
+++ b/src/RepositoryRegistry.php
@@ -6,7 +6,7 @@ class RepositoryRegistry implements \ArrayAccess, \Countable
     /**
      * @var array Initial registry class map. Contains only package builtin repositories.
      */
-    protected $map = [
+    protected array $map = [
         'nodes'                  => Repositories\NodeRepository::class,
         'quotas'                 => Repositories\QuotaRepository::class,
         'pods'                   => Repositories\PodRepository::class,
@@ -51,27 +51,27 @@ class RepositoryRegistry implements \ArrayAccess, \Countable
 
     }
 
-    public function offsetExists($method)
+    public function offsetExists($offset): bool
     {
-        return isset($this->map[$method]);
+        return isset($this->map[$offset]);
     }
 
-    public function offsetGet($method)
+    public function offsetGet($offset)
     {
-        return $this->map[$method];
+        return $this->map[$offset];
     }
 
-    public function offsetSet($method, $class)
+    public function offsetSet($offset, $value): void
     {
-        $this->map[$method] = $class;
+        $this->map[$offset] = $value;
     }
 
-    public function offsetUnset($method)
+    public function offsetUnset($offset): void
     {
-        unset($this->map[$method]);
+        unset($this->map[$offset]);
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->map);
     }

--- a/src/RepositoryRegistry.php
+++ b/src/RepositoryRegistry.php
@@ -56,6 +56,7 @@ class RepositoryRegistry implements \ArrayAccess, \Countable
         return isset($this->map[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->map[$offset];

--- a/src/RepositoryRegistry.php
+++ b/src/RepositoryRegistry.php
@@ -4,7 +4,7 @@ class RepositoryRegistry implements \ArrayAccess, \Countable
 {
 
     /**
-     * @var array Initial registry class map. Contains only package builtin repositories.
+     * Initial registry class map. Contains only package builtin repositories.
      */
     protected array $map = [
         'nodes'                  => Repositories\NodeRepository::class,

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -10,7 +10,7 @@ use Psr\Http\Client\ClientInterface;
 
 class ClientTest extends TestCase
 {
-	public function testSendRequestJsonParsesResponse()
+	public function testSendRequestJsonParsesResponse(): void
 	{
 		$httpClientProp = new ReflectionProperty(Client::class, 'httpClient');
 		$httpClientProp->setAccessible(true);
@@ -58,7 +58,7 @@ class ClientTest extends TestCase
 		array  $expectedSendArgs,
 		int    $respStatusCode = 200,
 		array  $respHeaders = []
-	) {
+	): void {
 		$httpClientProp = new ReflectionProperty(Client::class, 'httpClient');
 		$httpClientProp->setAccessible(true);
 
@@ -78,7 +78,7 @@ class ClientTest extends TestCase
 		$httpClientProp->setValue($client, $mockHttpMethodsClient);
 	}
 
-	public function testGetPodsFromApi()
+	public function testGetPodsFromApi(): void
 	{
 		$client = new Client();
 
@@ -102,7 +102,7 @@ class ClientTest extends TestCase
 		$this->assertInstanceOf(Pod::class, $pod1);
 	}
 
-	public function providerForFailedResponses()
+	public function providerForFailedResponses(): array
 	{
 		return [
 			[
@@ -126,7 +126,7 @@ class ClientTest extends TestCase
 	/**
 	 * @dataProvider providerForFailedResponses
 	 */
-	public function testExceptionIsThrownOnFailureResponse(int $respCode, string $exceptionClass, string $msgRegEx)
+	public function testExceptionIsThrownOnFailureResponse(int $respCode, string $exceptionClass, string $msgRegEx): void
 	{
 		$client = new Client();
 

--- a/tests/RepositoryRegistryTest.php
+++ b/tests/RepositoryRegistryTest.php
@@ -5,14 +5,14 @@ use Maclof\Kubernetes\RepositoryRegistry;
 class RepositoryRegistryTest extends TestCase
 {
 
-    public function test_builtin_repositories()
+    public function test_builtin_repositories(): void
     {
         $registry = new RepositoryRegistry();
 
         $this->assertCount(22, $registry);
     }
 
-    public function test_add_repository()
+    public function test_add_repository(): void
     {
         $registry = new RepositoryRegistry();
         $class = '\Example\Class';

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,14 +9,14 @@ class TestCase extends PHPUnitTestCase
 	 *
 	 * @var string
 	 */
-	protected $apiVersion = 'v1';
+	protected string $apiVersion = 'v1';
 
 	/**
 	 * The namespace.
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'default';
+	protected string $namespace = 'default';
 
 	/**
 	 * Get the contents of a fixture.
@@ -24,12 +24,12 @@ class TestCase extends PHPUnitTestCase
 	 * @param  string $path
 	 * @return string|null
 	 */
-	protected function getFixture($path)
+	protected function getFixture(string $path): ?string
 	{
 		$path = __DIR__ . '/fixtures/' . $path;
 
 		if (!file_exists($path)) {
-			return;
+			return null;
 		}
 
 		$contents = file_get_contents($path);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,23 +6,16 @@ class TestCase extends PHPUnitTestCase
 {
 	/**
 	 * The api version.
-	 *
-	 * @var string
 	 */
 	protected string $apiVersion = 'v1';
 
 	/**
 	 * The namespace.
-	 *
-	 * @var string
 	 */
 	protected string $namespace = 'default';
 
 	/**
 	 * Get the contents of a fixture.
-	 *
-	 * @param  string $path
-	 * @return string|null
 	 */
 	protected function getFixture(string $path): ?string
 	{

--- a/tests/collections/CertificateCollectionTest.php
+++ b/tests/collections/CertificateCollectionTest.php
@@ -4,20 +4,20 @@ use Maclof\Kubernetes\Collections\CertificateCollection;
 
 class CertificateCollectionTest extends TestCase
 {
-    protected $items = [
+    protected array $items = [
         [],
         [],
         [],
     ];
 
-    protected function getCertificateCollection()
+    protected function getCertificateCollection(): CertificateCollection
     {
         $configMapCollection = new CertificateCollection($this->items);
 
         return $configMapCollection;
     }
 
-    public function test_get_items()
+    public function test_get_items(): void
     {
         $certificateCollection = $this->getCertificateCollection();
         $items = $certificateCollection->toArray();

--- a/tests/collections/ConfigMapCollectionTest.php
+++ b/tests/collections/ConfigMapCollectionTest.php
@@ -4,20 +4,20 @@ use Maclof\Kubernetes\Collections\ConfigMapCollection;
 
 class ConfigMapCollectionTest extends TestCase
 {
-	protected $items = [
+	protected array $items = [
 		[],
 		[],
 		[],
 	];
 
-	protected function getConfigMapCollection()
+	protected function getConfigMapCollection(): ConfigMapCollection
 	{
 		$configMapCollection = new ConfigMapCollection($this->items);
 
 		return $configMapCollection;
 	}
 
-	public function test_get_items()
+	public function test_get_items(): void
 	{
 		$configMapCollection = $this->getConfigMapCollection();
 		$items = $configMapCollection->toArray();

--- a/tests/collections/DeploymentCollectionTest.php
+++ b/tests/collections/DeploymentCollectionTest.php
@@ -4,20 +4,20 @@ use Maclof\Kubernetes\Collections\DeploymentCollection;
 
 class DeploymentCollectionTest extends TestCase
 {
-	protected $items = [
+	protected array $items = [
 		[],
 		[],
 		[],
 	];
 
-	protected function getDeploymentCollection()
+	protected function getDeploymentCollection(): DeploymentCollection
 	{
 		$deploymentCollection = new DeploymentCollection($this->items);
 
 		return $deploymentCollection;
 	}
 
-	public function test_get_items()
+	public function test_get_items(): void
 	{
 		$deploymentCollection = $this->getDeploymentCollection();
 		$items = $deploymentCollection->toArray();

--- a/tests/collections/EndpointCollectionTest.php
+++ b/tests/collections/EndpointCollectionTest.php
@@ -4,20 +4,20 @@ use Maclof\Kubernetes\Collections\EndpointCollection;
 
 class EndpointCollectionTest extends TestCase
 {
-	protected $items = [
+	protected array $items = [
 		[],
 		[],
 		[],
 	];
 
-	protected function getEndpointCollection()
+	protected function getEndpointCollection(): EndpointCollection
 	{
 		$nodeCollection = new EndpointCollection($this->items);
 
 		return $nodeCollection;
 	}
 
-	public function test_get_items()
+	public function test_get_items(): void
 	{
 		$nodeCollection = $this->getEndpointCollection();
 		$items = $nodeCollection->toArray();

--- a/tests/collections/EventCollectionTest.php
+++ b/tests/collections/EventCollectionTest.php
@@ -4,20 +4,20 @@ use Maclof\Kubernetes\Collections\EventCollection;
 
 class EventCollectionTest extends TestCase
 {
-	protected $items = [
+	protected array $items = [
 		[],
 		[],
 		[],
 	];
 
-	protected function getEventCollection()
+	protected function getEventCollection(): EventCollection
 	{
 		$eventCollection = new EventCollection($this->items);
 
 		return $eventCollection;
 	}
 
-	public function test_get_items()
+	public function test_get_items(): void
 	{
 		$eventCollection = $this->getEventCollection();
 		$items = $eventCollection->toArray();

--- a/tests/collections/IngressCollectionTest.php
+++ b/tests/collections/IngressCollectionTest.php
@@ -4,20 +4,20 @@ use Maclof\Kubernetes\Collections\IngressCollection;
 
 class IngressCollectionTest extends TestCase
 {
-	protected $items = [
+	protected array $items = [
 		[],
 		[],
 		[],
 	];
 
-	protected function getIngressCollection()
+	protected function getIngressCollection(): IngressCollection
 	{
 		$ingressCollection = new IngressCollection($this->items);
 
 		return $ingressCollection;
 	}
 
-	public function test_get_items()
+	public function test_get_items(): void
 	{
 		$ingressCollection = $this->getIngressCollection();
 		$items = $ingressCollection->toArray();

--- a/tests/collections/IssuerCollectionTest.php
+++ b/tests/collections/IssuerCollectionTest.php
@@ -4,20 +4,20 @@ use Maclof\Kubernetes\Collections\IssuerCollection;
 
 class IssuerCollectionTest extends TestCase
 {
-    protected $items = [
+    protected array $items = [
         [],
         [],
         [],
     ];
 
-    protected function getIssuerCollection()
+    protected function getIssuerCollection(): IssuerCollection
     {
         $issuerCollection = new IssuerCollection($this->items);
 
         return $issuerCollection;
     }
 
-    public function test_get_items()
+    public function test_get_items(): void
     {
         $issuerCollection = $this->getIssuerCollection();
         $items = $issuerCollection->toArray();

--- a/tests/collections/JobCollectionTest.php
+++ b/tests/collections/JobCollectionTest.php
@@ -4,20 +4,20 @@ use Maclof\Kubernetes\Collections\JobCollection;
 
 class JobCollectionTest extends TestCase
 {
-	protected $items = [
+	protected array $items = [
 		[],
 		[],
 		[],
 	];
 
-	protected function getJobCollection()
+	protected function getJobCollection(): JobCollection
 	{
 		$jobCollection = new JobCollection($this->items);
 
 		return $jobCollection;
 	}
 
-	public function test_get_items()
+	public function test_get_items(): void
 	{
 		$jobCollection = $this->getJobCollection();
 		$items = $jobCollection->toArray();

--- a/tests/collections/NamespaceCollectionTest.php
+++ b/tests/collections/NamespaceCollectionTest.php
@@ -4,20 +4,20 @@ use Maclof\Kubernetes\Collections\NamespaceCollection;
 
 class NamespaceCollectionTest extends TestCase
 {
-	protected $items = [
+	protected array $items = [
 		[],
 		[],
 		[],
 	];
 
-	protected function getNamespaceCollection()
+	protected function getNamespaceCollection(): NamespaceCollection
 	{
 		$namespaceCollection = new NamespaceCollection($this->items);
 
 		return $namespaceCollection;
 	}
 
-	public function test_get_items()
+	public function test_get_items(): void
 	{
         $namespaceCollection = $this->getNamespaceCollection();
 		$items = $namespaceCollection->toArray();

--- a/tests/collections/NetworkPolicyCollectionTest.php
+++ b/tests/collections/NetworkPolicyCollectionTest.php
@@ -4,20 +4,20 @@ use Maclof\Kubernetes\Collections\NetworkPolicyCollection;
 
 class NetworkPolicyCollectionTest extends TestCase
 {
-	protected $items = [
+	protected array $items = [
 		[],
 		[],
 		[],
 	];
 
-	protected function getNetworkPolicyCollection()
+	protected function getNetworkPolicyCollection(): NetworkPolicyCollection
 	{
 		$podCollection = new NetworkPolicyCollection($this->items);
 
 		return $podCollection;
 	}
 
-	public function test_get_items()
+	public function test_get_items(): void
 	{
 		$podCollection = $this->getNetworkPolicyCollection();
 		$items = $podCollection->toArray();

--- a/tests/collections/NodeCollectionTest.php
+++ b/tests/collections/NodeCollectionTest.php
@@ -4,20 +4,20 @@ use Maclof\Kubernetes\Collections\NodeCollection;
 
 class NodeCollectionTest extends TestCase
 {
-	protected $items = [
+	protected array $items = [
 		[],
 		[],
 		[],
 	];
 
-	protected function getNodeCollection()
+	protected function getNodeCollection(): NodeCollection
 	{
 		$nodeCollection = new NodeCollection($this->items);
 
 		return $nodeCollection;
 	}
 
-	public function test_get_items()
+	public function test_get_items(): void
 	{
 		$nodeCollection = $this->getNodeCollection();
 		$items = $nodeCollection->toArray();

--- a/tests/collections/PodCollectionTest.php
+++ b/tests/collections/PodCollectionTest.php
@@ -4,20 +4,20 @@ use Maclof\Kubernetes\Collections\PodCollection;
 
 class PodCollectionTest extends TestCase
 {
-	protected $items = [
+	protected array $items = [
 		[],
 		[],
 		[],
 	];
 
-	protected function getPodCollection()
+	protected function getPodCollection(): PodCollection
 	{
 		$podCollection = new PodCollection($this->items);
 
 		return $podCollection;
 	}
 
-	public function test_get_items()
+	public function test_get_items(): void
 	{
 		$podCollection = $this->getPodCollection();
 		$items = $podCollection->toArray();

--- a/tests/collections/ReplicaSetCollectionTest.php
+++ b/tests/collections/ReplicaSetCollectionTest.php
@@ -4,20 +4,20 @@ use Maclof\Kubernetes\Collections\ReplicaSetCollection;
 
 class ReplicaSetCollectionTest extends TestCase
 {
-	protected $items = [
+	protected array $items = [
 		[],
 		[],
 		[],
 	];
 
-	protected function getReplicaSetCollection()
+	protected function getReplicaSetCollection(): ReplicaSetCollection
 	{
 		$replicaSetCollection = new ReplicaSetCollection($this->items);
 
 		return $replicaSetCollection;
 	}
 
-	public function test_get_items()
+	public function test_get_items(): void
 	{
 		$replicaSetCollection = $this->getReplicaSetCollection();
 		$items = $replicaSetCollection->toArray();

--- a/tests/collections/ReplicationControllerCollectionTest.php
+++ b/tests/collections/ReplicationControllerCollectionTest.php
@@ -4,20 +4,20 @@ use Maclof\Kubernetes\Collections\ReplicationControllerCollection;
 
 class ReplicationControllerCollectionTest extends TestCase
 {
-	protected $items = [
+	protected array $items = [
 		[],
 		[],
 		[],
 	];
 
-	protected function getReplicationControllerCollection()
+	protected function getReplicationControllerCollection(): ReplicationControllerCollection
 	{
 		$replicationControllerCollection = new ReplicationControllerCollection($this->items);
 
 		return $replicationControllerCollection;
 	}
 
-	public function test_get_items()
+	public function test_get_items(): void
 	{
 		$replicationControllerCollection = $this->getReplicationControllerCollection();
 		$items = $replicationControllerCollection->toArray();

--- a/tests/collections/SecretCollectionTest.php
+++ b/tests/collections/SecretCollectionTest.php
@@ -4,20 +4,20 @@ use Maclof\Kubernetes\Collections\SecretCollection;
 
 class SecretCollectionTest extends TestCase
 {
-	protected $items = [
+	protected array $items = [
 		[],
 		[],
 		[],
 	];
 
-	protected function getSecretCollection()
+	protected function getSecretCollection(): SecretCollection
 	{
 		$secretCollection = new SecretCollection($this->items);
 
 		return $secretCollection;
 	}
 
-	public function test_get_items()
+	public function test_get_items(): void
 	{
 		$secretCollection = $this->getSecretCollection();
 		$items = $secretCollection->toArray();

--- a/tests/collections/ServiceCollectionTest.php
+++ b/tests/collections/ServiceCollectionTest.php
@@ -4,20 +4,20 @@ use Maclof\Kubernetes\Collections\ServiceCollection;
 
 class ServiceCollectionTest extends TestCase
 {
-	protected $items = [
+	protected array $items = [
 		[],
 		[],
 		[],
 	];
 
-	protected function getServiceCollection()
+	protected function getServiceCollection(): ServiceCollection
 	{
 		$serviceCollection = new ServiceCollection($this->items);
 
 		return $serviceCollection;
 	}
 
-	public function test_get_items()
+	public function test_get_items(): void
 	{
 		$serviceCollection = $this->getServiceCollection();
 		$items = $serviceCollection->toArray();

--- a/tests/models/CertificateTest.php
+++ b/tests/models/CertificateTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\Certificate;
 
 class CertificateTest extends TestCase
 {
-    public function test_get_schema()
+    public function test_get_schema(): void
     {
         $certificate = new Certificate;
 
@@ -14,7 +14,7 @@ class CertificateTest extends TestCase
         $this->assertEquals($fixture, $schema);
     }
 
-    public function test_get_metadata()
+    public function test_get_metadata(): void
     {
         $certificate = new Certificate([
             'metadata' => [

--- a/tests/models/ConfigMapTest.php
+++ b/tests/models/ConfigMapTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\ConfigMap;
 
 class ConfigMapTest extends TestCase
 {
-	public function test_get_schema()
+	public function test_get_schema(): void
 	{
 		$configMap = new ConfigMap;
 
@@ -14,7 +14,7 @@ class ConfigMapTest extends TestCase
 		$this->assertEquals($schema, $fixture);
 	}
 
-	public function test_get_metadata()
+	public function test_get_metadata(): void
 	{
 		$configMap = new ConfigMap([
 			'metadata' => [

--- a/tests/models/CronJobTest.php
+++ b/tests/models/CronJobTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\CronJob;
 
 class CronJobTest extends TestCase
 {
-	public function test_get_schema()
+	public function test_get_schema(): void
 	{
 		$cronJob = new CronJob;
 
@@ -14,7 +14,7 @@ class CronJobTest extends TestCase
 		$this->assertEquals($schema, $fixture);
 	}
 
-	public function test_get_metadata()
+	public function test_get_metadata(): void
 	{
 		$cronJob = new CronJob([
 			'metadata' => [
@@ -27,7 +27,7 @@ class CronJobTest extends TestCase
 		$this->assertEquals($metadata, 'test');
 	}
 
-	public function test_set_api_version()
+	public function test_set_api_version(): void
 	{
 		$cronJob = new CronJob;
 

--- a/tests/models/DeploymentTest.php
+++ b/tests/models/DeploymentTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\Deployment;
 
 class DeploymentTest extends TestCase
 {
-	public function test_get_schema()
+	public function test_get_schema(): void
 	{
 		$deployment = new Deployment;
 
@@ -14,7 +14,7 @@ class DeploymentTest extends TestCase
 		$this->assertEquals($schema, $fixture);
 	}
 
-	public function test_get_metadata()
+	public function test_get_metadata(): void
 	{
 		$deployment = new Deployment([
 			'metadata' => [

--- a/tests/models/EndpointTest.php
+++ b/tests/models/EndpointTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\Endpoint;
 
 class EndpointTest extends TestCase
 {
-	public function test_get_schema()
+	public function test_get_schema(): void
 	{
 		$node = new Endpoint;
 
@@ -14,7 +14,7 @@ class EndpointTest extends TestCase
 		$this->assertEquals($schema, $fixture);
 	}
 
-	public function test_get_metadata()
+	public function test_get_metadata(): void
 	{
 		$node = new Endpoint([
 			'metadata' => [

--- a/tests/models/EventTest.php
+++ b/tests/models/EventTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\Event;
 
 class EventTest extends TestCase
 {
-	public function test_get_schema()
+	public function test_get_schema(): void
 	{
 		$event = new Event;
 
@@ -14,7 +14,7 @@ class EventTest extends TestCase
 		$this->assertEquals($schema, $fixture);
 	}
 
-	public function test_get_metadata()
+	public function test_get_metadata(): void
 	{
 		$event = new Event([
 			'metadata' => [

--- a/tests/models/IngressTest.php
+++ b/tests/models/IngressTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\Ingress;
 
 class IngressTest extends TestCase
 {
-	public function test_get_schema()
+	public function test_get_schema(): void
 	{
 		$ingress = new Ingress;
 
@@ -14,7 +14,7 @@ class IngressTest extends TestCase
 		$this->assertEquals($schema, $fixture);
 	}
 
-	public function test_get_metadata()
+	public function test_get_metadata(): void
 	{
 		$ingress = new Ingress([
 			'metadata' => [

--- a/tests/models/IssuerTest.php
+++ b/tests/models/IssuerTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\Issuer;
 
 class IssuerTest extends TestCase
 {
-    public function test_get_schema()
+    public function test_get_schema(): void
     {
         $issuer = new Issuer;
 
@@ -14,7 +14,7 @@ class IssuerTest extends TestCase
         $this->assertEquals($fixture, $schema);
     }
 
-    public function test_get_metadata()
+    public function test_get_metadata(): void
     {
         $issuer = new Issuer([
             'metadata' => [

--- a/tests/models/JobTest.php
+++ b/tests/models/JobTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\Job;
 
 class JobTest extends TestCase
 {
-	public function test_get_schema()
+	public function test_get_schema(): void
 	{
 		$job = new Job;
 
@@ -14,7 +14,7 @@ class JobTest extends TestCase
 		$this->assertEquals($schema, $fixture);
 	}
 
-	public function test_get_metadata()
+	public function test_get_metadata(): void
 	{
 		$job = new Job([
 			'metadata' => [

--- a/tests/models/ModelTest.php
+++ b/tests/models/ModelTest.php
@@ -7,7 +7,7 @@ use TestCase;
 
 class ModelTest extends TestCase
 {
-    public function testGetJsonPath()
+    public function testGetJsonPath(): void
     {
         $expected = 'foo';
 
@@ -20,7 +20,7 @@ class ModelTest extends TestCase
         $this->assertEquals($expected, $actual[0]);
     }
 
-    public function testIsGettingSchema()
+    public function testIsGettingSchema(): void
     {
         $expected = json_encode([
             'kind' => 'ConcreteModel',
@@ -35,7 +35,7 @@ class ModelTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetApiVersion()
+    public function testGetApiVersion(): void
     {
         $expected = 'v1';
 
@@ -46,7 +46,7 @@ class ModelTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetMetadata()
+    public function testGetMetadata(): void
     {
         $expected = 'foo';
 
@@ -57,7 +57,7 @@ class ModelTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testIsConvertingToArray()
+    public function testIsConvertingToArray(): void
     {
         $expected = ['foo' => 'bar'];
 
@@ -69,7 +69,7 @@ class ModelTest extends TestCase
 
     }
 
-    public function testIsReturningSchemaOnToStringCall()
+    public function testIsReturningSchemaOnToStringCall(): void
     {
         $model = new ConcreteModel();
 

--- a/tests/models/NamespaceTest.php
+++ b/tests/models/NamespaceTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\NamespaceModel;
 
 class NamespaceTest extends TestCase
 {
-	public function test_get_schema()
+	public function test_get_schema(): void
 	{
 		$namespace = new NamespaceModel;
 
@@ -14,7 +14,7 @@ class NamespaceTest extends TestCase
 		$this->assertEquals($schema, $fixture);
 	}
 
-	public function test_get_metadata()
+	public function test_get_metadata(): void
 	{
 		$node = new NamespaceModel([
 			'metadata' => [

--- a/tests/models/NetworkPolicyTest.php
+++ b/tests/models/NetworkPolicyTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\NetworkPolicy;
 
 class NetworkPolicyTest extends TestCase
 {
-	public function test_get_schema()
+	public function test_get_schema(): void
 	{
 		$policy = new NetworkPolicy();
 
@@ -14,7 +14,7 @@ class NetworkPolicyTest extends TestCase
 		$this->assertEquals($schema, $fixture);
 	}
 
-	public function test_get_metadata()
+	public function test_get_metadata(): void
 	{
 		$policy = new NetworkPolicy([
 			'metadata' => [

--- a/tests/models/NodeTest.php
+++ b/tests/models/NodeTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\Node;
 
 class NodeTest extends TestCase
 {
-	public function test_get_schema()
+	public function test_get_schema(): void
 	{
 		$node = new Node;
 
@@ -14,7 +14,7 @@ class NodeTest extends TestCase
 		$this->assertEquals($schema, $fixture);
 	}
 
-	public function test_get_metadata()
+	public function test_get_metadata(): void
 	{
 		$node = new Node([
 			'metadata' => [

--- a/tests/models/PodTest.php
+++ b/tests/models/PodTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\Pod;
 
 class PodTest extends TestCase
 {
-	public function test_get_schema()
+	public function test_get_schema(): void
 	{
 		$pod = new Pod;
 
@@ -14,7 +14,7 @@ class PodTest extends TestCase
 		$this->assertEquals($schema, $fixture);
 	}
 
-	public function test_get_metadata()
+	public function test_get_metadata(): void
 	{
 		$pod = new Pod([
 			'metadata' => [

--- a/tests/models/ReplicaSetTest.php
+++ b/tests/models/ReplicaSetTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\ReplicaSet;
 
 class ReplicaSetTest extends TestCase
 {
-	public function test_get_schema()
+	public function test_get_schema(): void
 	{
 		$replicaSet = new ReplicaSet;
 
@@ -14,7 +14,7 @@ class ReplicaSetTest extends TestCase
 		$this->assertEquals($schema, $fixture);
 	}
 
-	public function test_get_metadata()
+	public function test_get_metadata(): void
 	{
 		$replicaSet = new ReplicaSet([
 			'metadata' => [

--- a/tests/models/ReplicationControllerTest.php
+++ b/tests/models/ReplicationControllerTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\ReplicationController;
 
 class ReplicationControllerTest extends TestCase
 {
-	public function test_get_schema()
+	public function test_get_schema(): void
 	{
 		$replicationController = new ReplicationController;
 
@@ -14,7 +14,7 @@ class ReplicationControllerTest extends TestCase
 		$this->assertEquals($schema, $fixture);
 	}
 
-	public function test_get_metadata()
+	public function test_get_metadata(): void
 	{
 		$replicationController = new ReplicationController([
 			'metadata' => [

--- a/tests/models/SecretTest.php
+++ b/tests/models/SecretTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\Secret;
 
 class SecretTest extends TestCase
 {
-	public function test_get_schema()
+	public function test_get_schema(): void
 	{
 		$secret = new Secret;
 
@@ -14,7 +14,7 @@ class SecretTest extends TestCase
 		$this->assertEquals($schema, $fixture);
 	}
 
-	public function test_get_metadata()
+	public function test_get_metadata(): void
 	{
 		$secret = new Secret([
 			'metadata' => [

--- a/tests/models/ServiceTest.php
+++ b/tests/models/ServiceTest.php
@@ -4,7 +4,7 @@ use Maclof\Kubernetes\Models\Service;
 
 class ServiceTest extends TestCase
 {
-	public function test_get_schema()
+	public function test_get_schema(): void
 	{
 		$service = new Service;
 
@@ -14,7 +14,7 @@ class ServiceTest extends TestCase
 		$this->assertEquals($schema, $fixture);
 	}
 
-	public function test_get_metadata()
+	public function test_get_metadata(): void
 	{
 		$service = new Service([
 			'metadata' => [


### PR DESCRIPTION
This pull request will raise the minimum version of PHP to the least supported version 7.4 and will drop support for the eol versions prior to PHP 7.4.

It will intrduce native parameter and return type hints and drop redundand type information from the doc blocks.

Closes #98