### PR TITLE
Support Symfony Yaml 6 and enable test on php 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: bionic
 php:
   - 7.4
   - 8.0
-  - 8.1
+  #- 8.1 PHP8.1 is not available on travis's bionic distribution
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ dist: bionic
 
 php:
   - 7.4
-#  - 8.0 # PHP 8.0 requires PHPUnit to be upgraded, which then would break earlier versions
+  - 8.0
+  - 8.1
 
 env:
   global:

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
 		"php-http/discovery"    : "^1.0",
 		"illuminate/support"    : "^5.0|^6.0|^7.0|^8.0",
 		"ratchet/pawl"          : "^0.3",
-		"symfony/yaml"          : "^4.0|^5.0",
+		"symfony/yaml"          : "^4.0|^5.0|^6.0",
 		"softcreatr/jsonpath"   : "^0.6"
 	},
 	"require-dev": {
-		"phpunit/phpunit"            : "~7.0",
+		"phpunit/phpunit"            : "~7.0|~9.5",
 		"mockery/mockery"            : "~1.2",
 		"php-coveralls/php-coveralls": "~2.0",
 		"nyholm/psr7": "^1.4"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
 	"require": {
 		"php"                   : "^7.4|^8.0",
 		"php-http/client-common": "^2.0",
-		"php-http/socket-client": "^2.0",
 		"php-http/discovery"    : "^1.0",
 		"illuminate/support"    : "^5.0|^6.0|^7.0|^8.0",
 		"ratchet/pawl"          : "^0.3",
@@ -23,6 +22,7 @@
 		"phpunit/phpunit"            : "~7.0|~9.5",
 		"mockery/mockery"            : "~1.2",
 		"php-coveralls/php-coveralls": "~2.0",
+		"php-http/socket-client"     : "^2.0",
 		"nyholm/psr7": "^1.4"
 	},
 	"autoload": {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -8,6 +8,8 @@ use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Response;
 use Psr\Http\Client\ClientInterface;
 
+use function method_exists;
+
 class ClientTest extends TestCase
 {
 	public function testSendRequestJsonParsesResponse(): void
@@ -138,7 +140,11 @@ class ClientTest extends TestCase
 		);
 
 		$this->expectException($exceptionClass);
-		$this->expectExceptionMessageRegExp($msgRegEx);
+		if (method_exists($this, 'expectExceptionMessageRegExp')) {
+			$this->expectExceptionMessageRegExp($msgRegEx);
+		} else {
+			$this->expectExceptionMessageMatches($msgRegEx);
+		}
 		$client->sendRequest('GET', '/api/anything');
 	}
 }


### PR DESCRIPTION
Support versions Symfony Yaml 6+ parsers
Support PHPUnit 9.5+ and `expectExceptionMessageMatches` instead of `expectExceptionMessageRegExp` to can install dependencies with PHP8.1
Enable automatics tests on PHP 8.1