### PR TITLE
Some improvement with last version of Kubernetes API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"php"                   : "^7.4|^8.0",
 		"php-http/client-common": "^2.0",
 		"php-http/discovery"    : "^1.0",
-		"illuminate/support"    : "^5.0|^6.0|^7.0|^8.0",
+		"illuminate/support"    : "^5.0|^6.0|^7.0|^8.0|^9.0",
 		"ratchet/pawl"          : "^0.3",
 		"symfony/yaml"          : "^4.0|^5.0|^6.0",
 		"softcreatr/jsonpath"   : "^0.6"

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,6 +4,9 @@ use Exception;
 use InvalidArgumentException;
 use BadMethodCallException;
 use Maclof\Kubernetes\Exceptions\ApiServerException;
+use Maclof\Kubernetes\Repositories\RoleBindingRepository;
+use Maclof\Kubernetes\Repositories\RoleRepository;
+use Maclof\Kubernetes\Repositories\ServiceAccountRepository;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException as YamlParseException;
@@ -63,6 +66,9 @@ use Maclof\Kubernetes\Repositories\NamespaceRepository;
  * @method HorizontalPodAutoscalerRepository horizontalPodAutoscalers()
  * @method CertificateRepository certificates()
  * @method IssuersRepository issuers()
+ * @method ServiceAccountRepository serviceAccounts()
+ * @method RoleRepository roles()
+ * @method RoleBindingRepository roleBindings()
  */
 class Client
 {

--- a/src/Client.php
+++ b/src/Client.php
@@ -8,7 +8,6 @@ use Psr\Http\Client\ClientInterface;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException as YamlParseException;
 
-use Http\Client\HttpClient;
 use Http\Client\Common\HttpMethodsClient;
 use Http\Client\Common\HttpMethodsClientInterface;
 use Http\Client\Exception\TransferException as HttpTransferException;
@@ -381,6 +380,9 @@ class Client
 
 		try {
 			$headers = $method === 'PATCH' ? $this->patchHeaders : [];
+			if ('POST' === $method) {
+				$headers['Content-Type'] = 'application/json';
+			}
 
 			if ($this->token) {
 				$token = $this->token;

--- a/src/Collections/RoleBindingCollection.php
+++ b/src/Collections/RoleBindingCollection.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maclof\Kubernetes\Collections;
+
+use Maclof\Kubernetes\Models\RoleBinding;
+
+/**
+ * @author      Richard Déloge <richarddeloge@gmail.com>
+ */
+class RoleBindingCollection extends Collection
+{
+    /**
+     * @param array<int, array<mixed>|RoleBinding> $items
+     */
+    public function __construct(array $items)
+    {
+        parent::__construct($this->getServiceAccounts($items));
+    }
+
+    /**
+     * Get an array of serviceAccounts.
+     *
+     * @param  array<int, array<mixed>|RoleBinding> $items
+     * @return array<RoleBinding>
+     */
+    protected function getServiceAccounts(array $items)
+    {
+        $final = [];
+        foreach ($items as &$item) {
+            if (!$item instanceof RoleBinding) {
+                $final[] = new RoleBinding($item);
+            } else {
+                $final[] = $item;
+            }
+        }
+
+        return $final;
+    }
+}

--- a/src/Collections/RoleCollection.php
+++ b/src/Collections/RoleCollection.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maclof\Kubernetes\Collections;
+
+use Maclof\Kubernetes\Models\Role;
+
+/**
+ * @author      Richard Déloge <richarddeloge@gmail.com>
+ */
+class RoleCollection extends Collection
+{
+    /**
+     * @param array<int, array<mixed>|Role> $items
+     */
+    public function __construct(array $items)
+    {
+        parent::__construct($this->getServiceAccounts($items));
+    }
+
+    /**
+     * Get an array of serviceAccounts.
+     *
+     * @param  array<int, array<mixed>|Role> $items
+     * @return array<Role>
+     */
+    protected function getServiceAccounts(array $items)
+    {
+        $final = [];
+        foreach ($items as &$item) {
+            if (!$item instanceof Role) {
+                $final[] = new Role($item);
+            } else {
+                $final[] = $item;
+            }
+        }
+
+        return $final;
+    }
+}

--- a/src/Collections/ServiceAccountCollection.php
+++ b/src/Collections/ServiceAccountCollection.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maclof\Kubernetes\Collections;
+
+use Maclof\Kubernetes\Models\ServiceAccount;
+
+/**
+ * @author      Richard Déloge <richarddeloge@gmail.com>
+ */
+class ServiceAccountCollection extends Collection
+{
+    /**
+     * @param array<int, array<mixed>|ServiceAccount> $items
+     */
+    public function __construct(array $items)
+    {
+        parent::__construct($this->getServiceAccounts($items));
+    }
+
+    /**
+     * Get an array of serviceAccounts.
+     *
+     * @param  array<int, array<mixed>|ServiceAccount> $items
+     * @return array<ServiceAccount>
+     */
+    protected function getServiceAccounts(array $items)
+    {
+        $final = [];
+        foreach ($items as &$item) {
+            if (!$item instanceof ServiceAccount) {
+                $final[] = new ServiceAccount($item);
+            } else {
+                $final[] = $item;
+            }
+        }
+
+        return $final;
+    }
+}

--- a/src/Models/CronJob.php
+++ b/src/Models/CronJob.php
@@ -5,5 +5,5 @@ class CronJob extends Model
 	/**
 	 * The api version.
 	 */
-	protected string $apiVersion = 'batch/v1beta1';
+	protected string $apiVersion = 'batch/v1';
 }

--- a/src/Models/DaemonSet.php
+++ b/src/Models/DaemonSet.php
@@ -5,5 +5,5 @@ class DaemonSet extends Model
 	/**
 	 * The api version.
 	 */
-	protected string $apiVersion = 'extensions/v1beta1';
+	protected string $apiVersion = 'apps/v1';
 }

--- a/src/Models/HorizontalPodAutoscaler.php
+++ b/src/Models/HorizontalPodAutoscaler.php
@@ -5,5 +5,5 @@ class HorizontalPodAutoscaler extends \Maclof\Kubernetes\Models\Model
 	/**
 	 * The api version.
 	 */
-	protected string $apiVersion = 'autoscaling/v2beta1';
+	protected string $apiVersion = 'autoscaling/v2';
 }

--- a/src/Models/Ingress.php
+++ b/src/Models/Ingress.php
@@ -5,5 +5,5 @@ class Ingress extends Model
 	/**
 	 * The api version.
 	 */
-	protected string $apiVersion = 'networking.k8s.io/v1beta1';
+	protected string $apiVersion = 'networking.k8s.io/v1';
 }

--- a/src/Models/ReplicaSet.php
+++ b/src/Models/ReplicaSet.php
@@ -5,5 +5,5 @@ class ReplicaSet extends Model
 	/**
 	 * The api version.
 	 */
-	protected string $apiVersion = 'extensions/v1beta1';
+	protected string $apiVersion = 'apps/v1';
 }

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maclof\Kubernetes\Models;
+
+/**
+  * @author      Richard Déloge <richarddeloge@gmail.com>
+ */
+class Role extends Model
+{
+    /**
+     * @var string
+     */
+    protected string $apiVersion = 'rbac.authorization.k8s.io/v1';
+}

--- a/src/Models/RoleBinding.php
+++ b/src/Models/RoleBinding.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maclof\Kubernetes\Models;
+
+/**
+ * @author      Richard Déloge <richarddeloge@gmail.com>
+ */
+class RoleBinding extends Model
+{
+    /**
+     * @var string
+     */
+    protected string $apiVersion = 'rbac.authorization.k8s.io/v1';
+}

--- a/src/Models/ServiceAccount.php
+++ b/src/Models/ServiceAccount.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maclof\Kubernetes\Models;
+
+/**
+ * @author      Richard Déloge <richarddeloge@gmail.com>
+ */
+class ServiceAccount extends Model
+{
+}

--- a/src/Repositories/RoleBindingRepository.php
+++ b/src/Repositories/RoleBindingRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maclof\Kubernetes\Repositories;
+
+use Maclof\Kubernetes\Collections\RoleBindingCollection;
+use Maclof\Kubernetes\Models\RoleBinding;
+use Maclof\Kubernetes\Collections\Collection;
+
+/**
+ * @author      Richard Déloge <richarddeloge@gmail.com>
+ */
+class RoleBindingRepository extends Repository
+{
+    protected string $uri = 'rolebindings';
+
+    /**
+     * @param array{items: array<int, array<mixed>|RoleBinding>} $response
+     */
+    protected function createCollection(array $response): Collection
+    {
+        return new RoleBindingCollection($response['items']);
+    }
+}

--- a/src/Repositories/RoleRepository.php
+++ b/src/Repositories/RoleRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maclof\Kubernetes\Repositories;
+
+use Maclof\Kubernetes\Collections\RoleCollection;
+use Maclof\Kubernetes\Models\Role;
+use Maclof\Kubernetes\Collections\Collection;
+
+/**
+ * @author      Richard Déloge <richarddeloge@gmail.com>
+ */
+class RoleRepository extends Repository
+{
+    protected string $uri = 'roles';
+
+    /**
+     * @param array{items: array<int, array<mixed>|Role>} $response
+     */
+    protected function createCollection(array $response): Collection
+    {
+        return new RoleCollection($response['items']);
+    }
+}

--- a/src/Repositories/ServiceAccountRepository.php
+++ b/src/Repositories/ServiceAccountRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Maclof\Kubernetes\Repositories;
+
+use Maclof\Kubernetes\Collections\ServiceAccountCollection;
+use Maclof\Kubernetes\Models\ServiceAccount;
+use Maclof\Kubernetes\Collections\Collection;
+
+/**
+ * @author      Richard Déloge <richarddeloge@gmail.com>
+ */
+class ServiceAccountRepository extends Repository
+{
+    protected string $uri = 'serviceaccounts';
+
+    /**
+     * @param array{items: array<int, array<mixed>|ServiceAccount>} $response
+     */
+    protected function createCollection(array $response): Collection
+    {
+        return new ServiceAccountCollection($response['items']);
+    }
+}

--- a/src/RepositoryRegistry.php
+++ b/src/RepositoryRegistry.php
@@ -20,30 +20,34 @@ class RepositoryRegistry implements \ArrayAccess, \Countable
         'persistentVolume'       => Repositories\PersistentVolumeRepository::class,
         'persistentVolumeClaims' => Repositories\PersistentVolumeClaimRepository::class,
         'namespaces'             => Repositories\NamespaceRepository::class,
+		'serviceAccounts'	     => Repositories\ServiceAccountRepository::class,
 
         // batch/v1
         'jobs'                   => Repositories\JobRepository::class,
 
-        // batch/v2alpha1
+        // batch/v2
         'cronJobs'               => Repositories\CronJobRepository::class,
 
         // apps/v1
         'deployments'            => Repositories\DeploymentRepository::class,
 
-        // extensions/v1beta1
+        // extensions/v1
         'daemonSets'             => Repositories\DaemonSetRepository::class,
         'ingresses'              => Repositories\IngressRepository::class,
 
-        // autoscaling/v2beta1
+        // autoscaling/v2
         'horizontalPodAutoscalers'  => Repositories\HorizontalPodAutoscalerRepository::class,
 
         // networking.k8s.io/v1
         'networkPolicies'        => Repositories\NetworkPolicyRepository::class,
 
-        // certmanager.k8s.io/v1alpha1
+        // certmanager.k8s.io/v1
         'certificates'           => Repositories\CertificateRepository::class,
         'issuers'                => Repositories\IssuerRepository::class,
 
+		//rbac.authorization.k8s.io/v1
+		'roles' 				 => Repositories\RoleRepository::class,
+		'roleBindings' 			 => Repositories\RoleBindingRepository::class,
     ];
 
     public function __construct()

--- a/tests/RepositoryRegistryTest.php
+++ b/tests/RepositoryRegistryTest.php
@@ -9,7 +9,7 @@ class RepositoryRegistryTest extends TestCase
     {
         $registry = new RepositoryRegistry();
 
-        $this->assertCount(22, $registry);
+        $this->assertCount(25, $registry);
     }
 
     public function test_add_repository(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -30,6 +30,6 @@ class TestCase extends PHPUnitTestCase
 		// Fix for windows encoded fixtures.
 		$contents = str_replace("\r\n", "\n", $contents);
 
-		return $contents;
+		return trim($contents, ' ' . PHP_EOL);
 	}
 }

--- a/tests/collections/RoleBindingCollectionTest.php
+++ b/tests/collections/RoleBindingCollectionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Maclof\Kubernetes\Collections\RoleBindingCollection;
+
+class RoleBindingCollectionTest extends TestCase
+{
+	protected array $items = [
+		[],
+		[],
+		[],
+	];
+
+	protected function getRoleBindingCollection(): RoleBindingCollection
+	{
+		$roleBindingCollection = new RoleBindingCollection($this->items);
+
+		return $roleBindingCollection;
+	}
+
+	public function test_get_items(): void
+	{
+		$roleBindingCollection = $this->getRoleBindingCollection();
+		$items = $roleBindingCollection->toArray();
+
+		$this->assertTrue(is_array($items));
+		$this->assertEquals(3, count($items));
+	}
+}

--- a/tests/collections/RoleCollectionTest.php
+++ b/tests/collections/RoleCollectionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Maclof\Kubernetes\Collections\RoleCollection;
+
+class RoleCollectionTest extends TestCase
+{
+	protected array $items = [
+		[],
+		[],
+		[],
+	];
+
+	protected function getRoleCollection(): RoleCollection
+	{
+		$roleCollection = new RoleCollection($this->items);
+
+		return $roleCollection;
+	}
+
+	public function test_get_items(): void
+	{
+		$roleCollection = $this->getRoleCollection();
+		$items = $roleCollection->toArray();
+
+		$this->assertTrue(is_array($items));
+		$this->assertEquals(3, count($items));
+	}
+}

--- a/tests/collections/ServiceAccountCollectionTest.php
+++ b/tests/collections/ServiceAccountCollectionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Maclof\Kubernetes\Collections\ServiceAccountCollection;
+
+class ServiceAccountCollectionTest extends TestCase
+{
+	protected array $items = [
+		[],
+		[],
+		[],
+	];
+
+	protected function getServiceAccountCollection(): ServiceAccountCollection
+	{
+		$serviceAccountCollection = new ServiceAccountCollection($this->items);
+
+		return $serviceAccountCollection;
+	}
+
+	public function test_get_items(): void
+	{
+		$serviceAccountCollection = $this->getServiceAccountCollection();
+		$items = $serviceAccountCollection->toArray();
+
+		$this->assertTrue(is_array($items));
+		$this->assertEquals(3, count($items));
+	}
+}

--- a/tests/fixtures/cron-jobs/empty.json
+++ b/tests/fixtures/cron-jobs/empty.json
@@ -1,4 +1,4 @@
 {
     "kind": "CronJob",
-    "apiVersion": "batch/v1beta1"
+    "apiVersion": "batch/v1"
 }

--- a/tests/fixtures/ingresses/empty.json
+++ b/tests/fixtures/ingresses/empty.json
@@ -1,4 +1,4 @@
 {
     "kind": "Ingress",
-    "apiVersion": "networking.k8s.io/v1beta1"
+    "apiVersion": "networking.k8s.io/v1"
 }

--- a/tests/fixtures/replica-sets/empty.json
+++ b/tests/fixtures/replica-sets/empty.json
@@ -1,4 +1,4 @@
 {
     "kind": "ReplicaSet",
-    "apiVersion": "extensions/v1beta1"
+    "apiVersion": "apps/v1"
 }

--- a/tests/fixtures/roles-bindings/empty.json
+++ b/tests/fixtures/roles-bindings/empty.json
@@ -1,0 +1,4 @@
+{
+    "kind": "RoleBinding",
+    "apiVersion": "rbac.authorization.k8s.io/v1"
+}

--- a/tests/fixtures/roles/empty.json
+++ b/tests/fixtures/roles/empty.json
@@ -1,0 +1,4 @@
+{
+    "kind": "Role",
+    "apiVersion": "rbac.authorization.k8s.io/v1"
+}

--- a/tests/fixtures/services-accounts/empty.json
+++ b/tests/fixtures/services-accounts/empty.json
@@ -1,0 +1,4 @@
+{
+    "kind": "ServiceAccount",
+    "apiVersion": "v1"
+}

--- a/tests/models/CronJobTest.php
+++ b/tests/models/CronJobTest.php
@@ -31,7 +31,7 @@ class CronJobTest extends TestCase
 	{
 		$cronJob = new CronJob;
 
-		$this->assertEquals($cronJob->getApiVersion(), 'batch/v1beta1');
+		$this->assertEquals($cronJob->getApiVersion(), 'batch/v1');
 
 		$cronJob->setApiVersion('batch/v2alpha1');
 		$this->assertEquals($cronJob->getApiVersion(), 'batch/v2alpha1');

--- a/tests/models/RoleBindingTest.php
+++ b/tests/models/RoleBindingTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Maclof\Kubernetes\Models\RoleBinding;
+
+class RoleBindingTest extends TestCase
+{
+	public function test_get_schema(): void
+	{
+		$roleBinding = new RoleBinding;
+
+		$schema = $roleBinding->getSchema();
+		$fixture = $this->getFixture('roles-bindings/empty.json');
+
+		$this->assertEquals($schema, $fixture);
+	}
+
+	public function test_get_metadata(): void
+	{
+		$roleBinding = new RoleBinding([
+			'metadata' => [
+				'name' => 'test',
+			],
+		]);
+
+		$metadata = $roleBinding->getMetadata('name');
+
+		$this->assertEquals($metadata, 'test');
+	}
+}

--- a/tests/models/RoleTest.php
+++ b/tests/models/RoleTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Maclof\Kubernetes\Models\Role;
+
+class RoleTest extends TestCase
+{
+	public function test_get_schema(): void
+	{
+		$role = new Role;
+
+		$schema = $role->getSchema();
+		$fixture = $this->getFixture('roles/empty.json');
+
+		$this->assertEquals($schema, $fixture);
+	}
+
+	public function test_get_metadata(): void
+	{
+		$role = new Role([
+			'metadata' => [
+				'name' => 'test',
+			],
+		]);
+
+		$metadata = $role->getMetadata('name');
+
+		$this->assertEquals($metadata, 'test');
+	}
+}

--- a/tests/models/ServiceAccountTest.php
+++ b/tests/models/ServiceAccountTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Maclof\Kubernetes\Models\ServiceAccount;
+
+class ServiceAccountTest extends TestCase
+{
+	public function test_get_schema(): void
+	{
+		$serviceAccount = new ServiceAccount;
+
+		$schema = $serviceAccount->getSchema();
+		$fixture = $this->getFixture('services-accounts/empty.json');
+
+		$this->assertEquals($schema, $fixture);
+	}
+
+	public function test_get_metadata(): void
+	{
+		$serviceAccount = new ServiceAccount([
+			'metadata' => [
+				'name' => 'test',
+			],
+		]);
+
+		$metadata = $serviceAccount->getMetadata('name');
+
+		$this->assertEquals($metadata, 'test');
+	}
+}


### PR DESCRIPTION
* POST Request as the ContentType fixed to application/json. PATCH requests stil unchanged. (With K3s, POST request are not accepted)
* Fix urls of api for CronJob, DaemonJob, HorizontalPodAutocaler, Ingress and Replicaset (404 errors on last k3s0
* Support Illuminate/support v9
* Add Role, RoleBinding and ServiceAccount