### PR TITLE
Add support for ephemeral containers

### DIFF
--- a/src/Repositories/PodRepository.php
+++ b/src/Repositories/PodRepository.php
@@ -32,4 +32,22 @@ class PodRepository extends Repository
 		$response = $this->client->sendRequest('POST', '/' . $this->uri . '/' . $pod->getMetadata('name') . '/exec', $queryParams);
 		return $response;
 	}
+
+    /**
+     * Attach an ephemeralContainer to a pod.
+     * 
+     * @param Pod $pod Pod object
+     * @param array $spec array representing the relevant strategic spec
+     * @see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#ephemeralcontainer-v1-core EphemeralContainer spec
+     * 
+     * @return array
+     */
+    public function debug(Pod $pod, array $spec): array
+    {
+        $patch = json_encode($spec);
+        
+        $this->client->setPatchType('strategic');
+
+        return $this->sendRequest('PATCH', '/' . $this->uri . '/' . $pod->getMetadata('name') . '/ephemeralcontainers', [], $patch, $this->namespace);
+    }
 }


### PR DESCRIPTION
This PR adds a `debug()` function to pod repositories which allows you to attach an ephemeral container to a running pod.

Functionally similar to `kubectl debug` but providing the ability to provide an entire EphemeralContainer spec (see: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#ephemeralcontainer-v1-core)

The $spec param should be an array of a strategic merge patch, ie:
```
[
	"spec" => [
		"ephemeralContainers" => [
			...
		]
	]
]
```