### PR TITLE
Resource metadata may also be an array

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -79,7 +79,7 @@ abstract class Model implements Arrayable
 	/**
 	 * Get some metadata.
 	 */
-	public function getMetadata(string $key): ?string
+	public function getMetadata(string $key)
 	{
 		return isset($this->attributes['metadata'][$key]) ? $this->attributes['metadata'][$key] : null;
 	}

--- a/tests/models/ModelTest.php
+++ b/tests/models/ModelTest.php
@@ -48,13 +48,19 @@ class ModelTest extends TestCase
 
     public function testGetMetadata(): void
     {
-        $expected = 'foo';
+		$model = new ConcreteModel(['metadata' => ['name' => 'foo', 'labels' => ['foo' => 'bar']]]);
 
-        $model = new ConcreteModel(['metadata' => ['name' => 'foo']]);
+		$expected = 'foo';
 
-        $actual = $model->getMetadata('name');
+		$actual = $model->getMetadata('name');
 
         $this->assertEquals($expected, $actual);
+
+		$expected = ['foo' => 'bar'];
+
+		$actual = $model->getMetadata('labels');
+
+		$this->assertEquals($expected, $actual);
     }
 
     public function testIsConvertingToArray(): void


### PR DESCRIPTION
I recently updated the maclof/kubernetes-client in my project. I had to make some adjustments (HTTPlug related, mostly) to my code, but I also ran into an issue that can only be fixed in the package itself. It seems return types were added to most, if not all, methods. For the `Model::getMetadata()` the return type is now set to `?string`, however, resource metadata in Kubernetes can also be an array (key/value pair). An example:
```yaml
kind: Pod
apiVersion: v1
metadata:
  name: my-pod
  namespace: my-namespace
  labels:
    managed-by: Helm
```
Here, `$pod->getMetadata('labels')` will return an array, but this does not match the return type.

I removed the return type from the `getMetadata()` method. Since the package still supports PHP 7.4, `mixed` or `string | array | null` is not allowed.

I also updated the unit test to account for this issue.