### PR TITLE
Remove usages of deprecated Client and Message discovery classes

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1,6 +1,8 @@
 <?php namespace Maclof\Kubernetes;
 
 use Exception;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use InvalidArgumentException;
 use BadMethodCallException;
 use Maclof\Kubernetes\Exceptions\ApiServerException;
@@ -15,8 +17,6 @@ use Http\Client\Common\HttpMethodsClient;
 use Http\Client\Common\HttpMethodsClientInterface;
 use Http\Client\Exception\TransferException as HttpTransferException;
 use Http\Message\RequestFactory as HttpRequestFactory;
-use Http\Discovery\HttpClientDiscovery;
-use Http\Discovery\MessageFactoryDiscovery as HttpMessageFactoryDiscovery;
 
 use React\EventLoop\Factory as ReactFactory;
 use React\Socket\Connector as ReactSocketConnector;
@@ -149,8 +149,8 @@ class Client
 		$this->setOptions($options);
 		$this->classRegistry = $repositoryRegistry ?: new RepositoryRegistry();
 		$this->httpClient = new HttpMethodsClient(
-			$httpClient ?: HttpClientDiscovery::find(),
-			$httpRequestFactory ?: HttpMessageFactoryDiscovery::find()
+			$httpClient ?: Psr18ClientDiscovery::find(),
+			$httpRequestFactory ?: Psr17FactoryDiscovery::findRequestFactory()
 		);
 	}
 


### PR DESCRIPTION
`HttpClientDiscovery` and `HttpMessageFactoryDiscovery` has been deprecated for a while now. And usage of `HttpMessageFactoryDiscovery` class forces us to require abandoned package (`php-http/message-factory`).

The issue we encountered was

```
No php-http message factories found. Note that the php-http message factories are deprecated in favor of the PSR-17 message factories. To use the legacy Guzzle, Diactoros or Slim Framework factories of php-http, install php-http/message and php-http/message-factory and the chosen message implementation.
```

To resolved the above issue we need to start using new discovery methods.