### PR TITLE
Fix: missing stream factory

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -10,6 +10,7 @@ use Maclof\Kubernetes\Repositories\RoleBindingRepository;
 use Maclof\Kubernetes\Repositories\RoleRepository;
 use Maclof\Kubernetes\Repositories\ServiceAccountRepository;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException as YamlParseException;
 
@@ -144,13 +145,14 @@ class Client
 	/**
 	 * The constructor.
 	 */
-	public function __construct(array $options = [], RepositoryRegistry $repositoryRegistry = null, ClientInterface $httpClient = null, HttpRequestFactory $httpRequestFactory = null)
+	public function __construct(array $options = [], RepositoryRegistry $repositoryRegistry = null, ClientInterface $httpClient = null, HttpRequestFactory $httpRequestFactory = null, StreamFactoryInterface $streamFactory = null)
 	{
 		$this->setOptions($options);
 		$this->classRegistry = $repositoryRegistry ?: new RepositoryRegistry();
 		$this->httpClient = new HttpMethodsClient(
 			$httpClient ?: Psr18ClientDiscovery::find(),
-			$httpRequestFactory ?: Psr17FactoryDiscovery::findRequestFactory()
+			$httpRequestFactory ?: Psr17FactoryDiscovery::findRequestFactory(),
+			$streamFactory ?: Psr17FactoryDiscovery::findStreamFactory(),
 		);
 	}
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -152,7 +152,7 @@ class Client
 		$this->httpClient = new HttpMethodsClient(
 			$httpClient ?: Psr18ClientDiscovery::find(),
 			$httpRequestFactory ?: Psr17FactoryDiscovery::findRequestFactory(),
-			$streamFactory ?: Psr17FactoryDiscovery::findStreamFactory(),
+			$streamFactory ?: Psr17FactoryDiscovery::findStreamFactory()
 		);
 	}
 


### PR DESCRIPTION
Allows to pass stream factory needed in order to work with newer versions of HttpMethodsClient.

https://github.com/php-http/client-common/blob/2.x/src/HttpMethodsClient.php#L45

