### PR TITLE
Add support for Symfony (Yaml) 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"php-http/discovery"    : "^1.0",
 		"illuminate/support"    : "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
 		"ratchet/pawl"          : "^0.3",
-		"symfony/yaml"          : "^4.0|^5.0|^6.0",
+		"symfony/yaml"          : "^4.0|^5.0|^6.0|^7.0",
 		"softcreatr/jsonpath"   : "^0.5 || ^0.7 || ^0.8"
 	},
 	"require-dev": {


### PR DESCRIPTION
This pull request is about allowing Symfony (Yaml) version 7.x.