### PR TITLE
Fix: Allow Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"php"                   : "^7.4|^8.0",
 		"php-http/client-common": "^2.0",
 		"php-http/discovery"    : "^1.0",
-		"illuminate/support"    : "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+		"illuminate/support"    : "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
 		"ratchet/pawl"          : "^0.3",
 		"symfony/yaml"          : "^4.0|^5.0|^6.0|^7.0",
 		"softcreatr/jsonpath"   : "^0.5 || ^0.7 || ^0.8"


### PR DESCRIPTION
It somehow still runs on L12 & php 8.4 :) I'm glad, just amazed
tested on real project