### PR TITLE
Fixing PHP8.4 deprecation message

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -145,7 +145,7 @@ class Client
 	/**
 	 * The constructor.
 	 */
-	public function __construct(array $options = [], RepositoryRegistry $repositoryRegistry = null, ClientInterface $httpClient = null, HttpRequestFactory $httpRequestFactory = null, StreamFactoryInterface $streamFactory = null)
+	public function __construct(array $options = [], ?RepositoryRegistry $repositoryRegistry = null, ?ClientInterface $httpClient = null, ?HttpRequestFactory $httpRequestFactory = null, ?StreamFactoryInterface $streamFactory = null)
 	{
 		$this->setOptions($options);
 		$this->classRegistry = $repositoryRegistry ?: new RepositoryRegistry();
@@ -383,7 +383,7 @@ class Client
 	 * @throws \Maclof\Kubernetes\Exceptions\BadRequestException
 	 */
 	#[\ReturnTypeWillChange]
-	public function sendRequest(string $method, string $uri, array $query = [], $body = null, bool $namespace = true, string $apiVersion = null, array $requestOptions = [])
+	public function sendRequest(string $method, string $uri, array $query = [], $body = null, bool $namespace = true, ?string $apiVersion = null, array $requestOptions = [])
 	{
 		$baseUri = $apiVersion ? ('apis/' . $apiVersion) : ('api/' . $this->apiVersion);
 		if ($namespace) {

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -155,7 +155,7 @@ abstract class Repository
 	/**
 	 * Delete a model.
 	 */
-	public function delete(Model $model, DeleteOptions $options = null): array
+	public function delete(Model $model, ?DeleteOptions $options = null): array
 	{
 		return $this->deleteByName((string)$model->getMetadata('name'), $options);
 	}
@@ -163,7 +163,7 @@ abstract class Repository
 	/**
 	 * Delete a model by name.
 	 */
-	public function deleteByName(string $name, DeleteOptions $options = null): array
+	public function deleteByName(string $name, ?DeleteOptions $options = null): array
 	{
 		$body = $options ? $options->getSchema() : null;
 


### PR DESCRIPTION
Fixing the following PHP warnings

```

FILE: /var/www/html/vendor/maclof/kubernetes-client/src/Client.php
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 5 WARNINGS AFFECTING 2 LINES
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 148 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter:
     |         | $repositoryRegistry.
 148 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter:
     |         | $httpClient.
 148 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter:
     |         | $httpRequestFactory.
 148 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter:
     |         | $streamFactory.
 386 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter:
     |         | $apiVersion.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


FILE: /var/www/html/vendor/maclof/kubernetes-client/src/Repositories/Repository.php
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 158 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $options.
 166 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $options.
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```